### PR TITLE
Fix documentation Getting Started page to only include sections

### DIFF
--- a/quickstart.ipynb
+++ b/quickstart.ipynb
@@ -420,7 +420,7 @@
     "id": "fh8y7CWg0di9"
    },
    "source": [
-    "### What if features being joined together have the same name (but come from different feature groups)?\n",
+    "**What if features being joined together have the same name (but come from different feature groups)?**\n",
     "\n",
     "The problem of name clashes when joining features together can easily happen. For example, recall that you computed the features in transactions_4h_aggs using 4-hour aggregates. If you had created another feature group for 12-hour aggregates, you may have designed an identical schema with the same feature names (just for 12-hours, not 4-hours). If you join features together with identical names from different feature groups, you should pass a prefix argument (e.g., `prefix='4hr'`) in the join operation to give the features unique names in the join object. See the [documentation](https://docs.hopsworks.ai) for more details.\n",
     "\n",
@@ -858,7 +858,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Try out your Model Interactively\n",
+    "##   Try out your Model Interactively\n",
     "\n",
     "We will build a user interface with Gradio to allow you to enter a credit card category and amount to see if the credit card transaction will be marked as suspected of fraud or not."
    ]
@@ -965,7 +965,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.8"
+   "version": "3.8.13"
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {


### PR DESCRIPTION
![Screenshot from 2022-07-29 16-02-22](https://user-images.githubusercontent.com/9936580/181776903-8befd864-6fb2-4623-a95f-70b95ba0d853.png)

This fixes the structure here to not show **What if features being joined together have the same name (but come from different feature groups)** as a header. Also add an icon to "Try out your model interactively".