### PR TITLE
Fix Column Naming Issue in process_df for Enhanced Pandas Compatibility

### DIFF
--- a/advanced_tutorials/citibike/features/citibike.py
+++ b/advanced_tutorials/citibike/features/citibike.py
@@ -62,8 +62,9 @@ def process_df(original_df, month, year):
     df_res = original_df[["started_at", "start_station_id"]]
     df_res.started_at = pd.to_datetime(df_res.started_at)
     df_res.started_at = df_res.started_at.dt.floor('d')
-    df_res = df_res.groupby(["started_at",
-                             "start_station_id"]).value_counts().reset_index()
+    df_res = (df_res.groupby(['started_at', 'start_station_id'])
+              .size()
+              .reset_index(name='users_count'))
     df_res = df_res.rename(columns={"started_at": "date",
                                     "start_station_id": "station_id",
                                     0: "users_count"})


### PR DESCRIPTION
## Fix Column Naming Issue in `process_df` for Enhanced Pandas Compatibility

### Background:
Recent versions of Pandas have introduced a change in the `groupby().value_counts()` method, where the resulting count column is automatically named `count` instead of using a numeric index (0). This behavior is observed from Pandas version 1.4.0 onwards.

### Issue:
In `citibike.py`, the `process_df` function relies on the older behavior, expecting a numeric index (0) for renaming the count column to `users_count`. With newer Pandas versions, this results in a column named `count` instead, leading to compatibility issues. Specifically, when `get_citibike_data` calls `process_df` and attempts to reset the index, it expects a `users_count` column, which doesn't exist in this scenario. Consequently, this discrepancy leads to a column of NaNs, affecting data integrity and downstream processing.

### Fix:
This pull request addresses the issue by explicitly renaming the count column to `users_count`, ensuring consistent behavior across different Pandas versions. The proposed change involves a minor but crucial modification in the `process_df` function, where the count column is explicitly defined, avoiding reliance on Pandas' automatic naming convention.

### Benefits:
This change ensures that `citibike.py` remains compatible with both older and newer versions of Pandas, thus enhancing the robustness and reliability of the data processing workflow in the `hopsworks-tutorials` repository.

I have thoroughly tested the updated code with multiple versions of Pandas to ensure compatibility and correctness of the data processing pipeline.
