### PR TITLE
[FSTORE-1186][APPEND] Adding tutorial for Polars

### DIFF
--- a/integrations/polars/quickstart_polars.ipynb
+++ b/integrations/polars/quickstart_polars.ipynb
@@ -270,9 +270,7 @@
    "source": [
     "import hopsworks\n",
     "\n",
-    "project = hopsworks.login(host = \"c.app.hopsworks.ai\", \n",
-    "                          api_key_value=\"pDqRJZfnqRvbmZ7b.PtADpllk5K808lKYuGiF4zQddu0uJb2EoxSPVJOU8iQlHk7Vo9tXlJNBhxfPZWpd\",\n",
-    "                         port=443)\n",
+    "project = hopsworks.login()\n",
     "\n",
     "fs = project.get_feature_store()"
    ]


### PR DESCRIPTION
- Removed api key from `hopsworks.login()` function in polars tutorial.