### PR TITLE
[FSTORE-1558] Fix timeseries tutorial for 4.0

### DIFF
--- a/advanced_tutorials/timeseries/2_training_pipeline.ipynb
+++ b/advanced_tutorials/timeseries/2_training_pipeline.ipynb
@@ -99,7 +99,7 @@
     "    .join(averages_fg.select_features())\n",
     "\n",
     "# Uncomment this if you would like to view your selected features\n",
-    "selected_features.show(5)"
+    "# selected_features.show(5)"
    ]
   },
   {

--- a/advanced_tutorials/timeseries/2_training_pipeline.ipynb
+++ b/advanced_tutorials/timeseries/2_training_pipeline.ipynb
@@ -96,10 +96,10 @@
    "source": [
     "# Select features for training data\n",
     "selected_features = price_fg.select_all() \\\n",
-    "    .join(averages_fg.select_except(['date']))\n",
+    "    .join(averages_fg.select_features())\n",
     "\n",
     "# Uncomment this if you would like to view your selected features\n",
-    "# selected_features.show(5)"
+    "selected_features.show(5)"
    ]
   },
   {
@@ -440,7 +440,7 @@
     "        \"\"\" Serves a prediction request usign a trained model\"\"\"\n",
     "        # Retrieve feature vectors\n",
     "        feature_vector = self.fv.get_feature_vector(\n",
-    "            entry = {'id': id_value[0]}\n",
+    "            entry = {'id': id_value[0][0]}\n",
     "        )\n",
     "        return self.model.predict(np.asarray(feature_vector[1:]).reshape(1, -1)).tolist()"
    ]
@@ -532,7 +532,7 @@
    "outputs": [],
    "source": [
     "# Predict price for the 1 ID\n",
-    "deployment.predict({'instances': [1]})"
+    "deployment.predict(inputs=[[1]])"
    ]
   },
   {
@@ -560,7 +560,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.18"
+   "version": "3.12.5"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
**Issue:** 
The training pipeline in timeseries tutorial 
- fails with the error `Provided feature name id is ambiguous` when creating a feature view. 
- The `deployment.predict` function was failing.

**Root Cause:**
- The primary key is duplicated in both feature groups used in the feature view. 
- Data provided to `deployment.predict` not the correct format required by Kserve which is the default for 4.0.

**Fix Done:**
- Used `select_feature` function in one of the tutorials so that the primary key is not duplicated.
- Corrected the data passed to `deployment.predict` function and updated the predict file accordingly.