### PR TITLE
[FSTORE-1559] Fix quickstart tutorial for 4.0

### DIFF
--- a/quickstart.ipynb
+++ b/quickstart.ipynb
@@ -907,7 +907,7 @@
     "    def predict(self, inputs):\n",
     "        \"\"\" Serves a prediction request usign a trained model\"\"\"\n",
     "        feature_vector = self.fv.get_feature_vector({\"cc_num\": inputs[0][0]})\n",
-    "        feature_vector = feature_vector[:-1]\n",
+    "        feature_vector = feature_vector[:-3] + feature_vector[-2:]\n",
     "        \n",
     "        return self.model.predict(np.asarray(feature_vector).reshape(1, -1)).tolist() # Numpy Arrays are not JSON serializable"
    ]
@@ -1134,7 +1134,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.18"
+   "version": "3.12.5"
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {


### PR DESCRIPTION
**Issue:**
`deployment.predict` fails with the error: 
`TypeError: float() argument must be a string or a real number, not 'datetime.datetime'`

**Root Cause:**
- The issue is caused by a datetime object being passed to the `model.predict` function in the `Predict` class. 
- In 3.8 the `datetime` object was returned as the last entry in the feature vector and it was removed by slicing the last entry out. 
- With the changes for transformation function in 4.0, the transformed features are the last entires in a feature vector. The predict class was not changed to handle this changes.

**Fix Done:**
Corrected the array slicing done in the `predict` function in the `Predict` class.
