### PR TITLE
[FSTORE-1559][APPEND] Fix quickstart tutorial for 4.0

### DIFF
--- a/quickstart.ipynb
+++ b/quickstart.ipynb
@@ -907,7 +907,7 @@
     "    def predict(self, inputs):\n",
     "        \"\"\" Serves a prediction request usign a trained model\"\"\"\n",
     "        feature_vector = self.fv.get_feature_vector({\"cc_num\": inputs[0][0]})\n",
-    "        feature_vector = feature_vector[:-3] + feature_vector[-2:]\n",
+    "        feature_vector = feature_vector[:-2] + feature_vector[-1:]\n",
     "        \n",
     "        return self.model.predict(np.asarray(feature_vector).reshape(1, -1)).tolist() # Numpy Arrays are not JSON serializable"
    ]


### PR DESCRIPTION
Issue:
deployment.predict fails with the error:
TypeError: float() argument must be a string or a real number, not 'datetime.datetime'

Root Cause:
The array was not sliced correctly in the Predict function in the predictor Script.

Fix Done:
Corrected the array slicing done in the predict function in the Predict class.