### PR TITLE
[HWORKS-494] Tutorials: pass local file paths to model.deploy()

### DIFF
--- a/api_examples/vllm/deepseek-r1-distill-llama31-8b/deploy_deepseek_r1_distill_llama31-8b.ipynb
+++ b/api_examples/vllm/deepseek-r1-distill-llama31-8b/deploy_deepseek_r1_distill_llama31-8b.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# A Guide for DeepSeek-R1 distilled Llama3.1-8B on Hopsworks\n",
     "\n",
-    "For details about this Large Language Model (LLM) visit the model page in the HuggingFace repository ➡️ [link](https://huggingface.co/deepseek-ai/DeepSeek-R1-Distill-Llama-8B)"
+    "For details about this Large Language Model (LLM) visit the model page in the HuggingFace repository \u27a1\ufe0f [link](https://huggingface.co/deepseek-ai/DeepSeek-R1-Distill-Llama-8B)"
    ]
   },
   {
@@ -15,7 +15,7 @@
    "id": "a01e6751",
    "metadata": {},
    "source": [
-    "### 1️⃣ Download DeepSeek-R1 distilled Llama3.1-8B using the huggingface_hub library\n",
+    "### 1\ufe0f\u20e3 Download DeepSeek-R1 distilled Llama3.1-8B using the huggingface_hub library\n",
     "\n",
     "First, we download the Llama3.1 model files (e.g., weights, configuration files) directly from the HuggingFace repository.\n"
    ]
@@ -56,7 +56,7 @@
    "id": "ca6a0afd",
    "metadata": {},
    "source": [
-    "## 2️⃣ Register DeepSeek-R1 distilled Llama3.1 8B-Instruct into Hopsworks Model Registry\n",
+    "## 2\ufe0f\u20e3 Register DeepSeek-R1 distilled Llama3.1 8B-Instruct into Hopsworks Model Registry\n",
     "\n",
     "Once the model files are downloaded from the HuggingFace repository, we can register the models files into the Hopsworks Model Registry."
    ]
@@ -108,7 +108,7 @@
    "id": "0ccd72b4",
    "metadata": {},
    "source": [
-    "## 3️⃣ Deploy DeepSeek-R1 distilled Llama3.1-8B\n",
+    "## 3\ufe0f\u20e3 Deploy DeepSeek-R1 distilled Llama3.1-8B\n",
     "\n",
     "After registering the LLM model into the Model Registry, we can create a deployment that serves it using the vLLM engine."
    ]
@@ -132,11 +132,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Upload vllm engine config file for the deployments\n",
-    "\n",
-    "ds_api = project.get_dataset_api()\n",
-    "\n",
-    "path_to_config_file = f\"/Projects/{project.name}/\" + ds_api.upload(\"deepseek_vllmconfig.yaml\", \"Resources\", overwrite=True)"
+    "# `deepseek_vllmconfig.yaml` is uploaded to HopsFS automatically by the SDK\n",
+    "# when the deployment is saved; no manual dataset_api.upload step needed."
    ]
   },
   {
@@ -144,7 +141,7 @@
    "id": "9826f0d9",
    "metadata": {},
    "source": [
-    "### 🟨 Using vLLM OpenAI server\n",
+    "### \ud83d\udfe8 Using vLLM OpenAI server\n",
     "\n",
     "Create a model deployment by providing a configuration file with the arguments for the vLLM engine."
    ]
@@ -159,7 +156,7 @@
     "deepseekr1_depl = deepseekr1.deploy(\n",
     "    name=\"deepseekr1\",\n",
     "    description=\"Deepseek-R1 distilled Llama3.1-8B from HuggingFace\",\n",
-    "    config_file=path_to_config_file,\n",
+    "    config_file=\"deepseek_vllmconfig.yaml\",\n",
     "    resources={\"num_instances\": 1, \"requests\": {\"cores\": 1, \"memory\": 1024*12, \"gpus\": 1}, \"limits\": {\"cores\": 2, \"memory\": 1024*16, \"gpus\": 1}},\n",
     ")"
    ]
@@ -220,7 +217,7 @@
    "id": "49f478b0",
    "metadata": {},
    "source": [
-    "## 4️⃣ Prompting DeepSeek-R1 distilled Llama3.1 8B-Instruct\n",
+    "## 4\ufe0f\u20e3 Prompting DeepSeek-R1 distilled Llama3.1 8B-Instruct\n",
     "\n",
     "Once the deployment is up and running, we can start sending user prompts to the LLM. You can either use an OpenAI API-compatible client (e.g., openai library) or any other http client."
    ]
@@ -238,7 +235,7 @@
    "id": "cedb83ac",
    "metadata": {},
    "source": [
-    "### 🟨 Using httpx"
+    "### \ud83d\udfe8 Using httpx"
    ]
   },
   {
@@ -300,7 +297,7 @@
    "id": "9bdc4d24",
    "metadata": {},
    "source": [
-    "### 🟨 Using OpenAI client"
+    "### \ud83d\udfe8 Using OpenAI client"
    ]
   },
   {

--- a/api_examples/vllm/gemma-2-9b-it/deploy_gemma2-9b-it.ipynb
+++ b/api_examples/vllm/gemma-2-9b-it/deploy_gemma2-9b-it.ipynb
@@ -6,14 +6,14 @@
    "source": [
     "# A Guide for Gemma 2 9B IT on Hopsworks\n",
     "\n",
-    "For details about this Large Language Model (LLM) visit the model page in the HuggingFace repository ➡️ [link](https://huggingface.co/google/gemma-2-9b-it)"
+    "For details about this Large Language Model (LLM) visit the model page in the HuggingFace repository \u27a1\ufe0f [link](https://huggingface.co/google/gemma-2-9b-it)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### 1️⃣ Download Gemma 2 9B IT using the huggingface_hub library\n",
+    "### 1\ufe0f\u20e3 Download Gemma 2 9B IT using the huggingface_hub library\n",
     "\n",
     "First, we download the Gemma 2 model files (e.g., weights, configuration files) directly from the HuggingFace repository.\n"
    ]
@@ -58,7 +58,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 2️⃣ Register Gemma 2 9B IT into Hopsworks Model Registry\n",
+    "## 2\ufe0f\u20e3 Register Gemma 2 9B IT into Hopsworks Model Registry\n",
     "\n",
     "Once the model files are downloaded from the HuggingFace repository, we can register the models files into the Hopsworks Model Registry."
    ]
@@ -104,7 +104,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 3️⃣ Deploy Gemma 2 9B IT\n",
+    "## 3\ufe0f\u20e3 Deploy Gemma 2 9B IT\n",
     "\n",
     "After registering the LLM model into the Model Registry, we can create a deployment that serves it using the vLLM engine with a user-provided configuration (yaml) file."
    ]
@@ -126,11 +126,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Upload vllm engine config file for the deployments\n",
-    "\n",
-    "ds_api = project.get_dataset_api()\n",
-    "\n",
-    "path_to_config_file = f\"/Projects/{project.name}/\" + ds_api.upload(\"gemma_vllmconfig.yaml\", \"Resources\", overwrite=True)"
+    "# `gemma_vllmconfig.yaml` is uploaded to HopsFS automatically by the SDK\n",
+    "# when the deployment is saved; no manual dataset_api.upload step needed."
    ]
   },
   {
@@ -142,7 +139,7 @@
     "gemma_depl = gemma.deploy(\n",
     "    name=\"gemma2v1\",\n",
     "    description=\"Gemma 2 9B IT from HuggingFace\",\n",
-    "    config_file=path_to_config_file,\n",
+    "    config_file=\"gemma_vllmconfig.yaml\",\n",
     "    resources={\"num_instances\": 1, \"requests\": {\"cores\": 1, \"memory\": 1024*12, \"gpus\": 1}, \"limits\": {\"cores\": 2, \"memory\": 1024*16, \"gpus\": 1}},\n",
     ")"
    ]
@@ -197,7 +194,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 4️⃣ Prompting Gemma 2 9B IT\n",
+    "## 4\ufe0f\u20e3 Prompting Gemma 2 9B IT\n",
     "\n",
     "Once the Gemma deployment is up and running, we can start sending user prompts to the LLM. You can either use an OpenAI API-compatible client (e.g., openai library) or any other http client."
    ]
@@ -213,7 +210,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### 🟨 Using httpx"
+    "### \ud83d\udfe8 Using httpx"
    ]
   },
   {
@@ -292,7 +289,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### 🟨 Using OpenAI client"
+    "### \ud83d\udfe8 Using OpenAI client"
    ]
   },
   {

--- a/api_examples/vllm/llama-3.1-8b-instruct/deploy_llama31-8b-instruct.ipynb
+++ b/api_examples/vllm/llama-3.1-8b-instruct/deploy_llama31-8b-instruct.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# A Guide for Llama3.1 8B-Instruct on Hopsworks\n",
     "\n",
-    "For details about this Large Language Model (LLM) visit the model page in the HuggingFace repository ➡️ [link](https://huggingface.co/meta-llama/Llama-3.1-8B-Instruct)"
+    "For details about this Large Language Model (LLM) visit the model page in the HuggingFace repository \u27a1\ufe0f [link](https://huggingface.co/meta-llama/Llama-3.1-8B-Instruct)"
    ]
   },
   {
@@ -15,7 +15,7 @@
    "id": "191915f4",
    "metadata": {},
    "source": [
-    "### 1️⃣ Download Llama3.1 8B-Instruct using the huggingface_hub library\n",
+    "### 1\ufe0f\u20e3 Download Llama3.1 8B-Instruct using the huggingface_hub library\n",
     "\n",
     "First, we download the Llama3.1 model files (e.g., weights, configuration files) directly from the HuggingFace repository.\n"
    ]
@@ -56,7 +56,7 @@
    "id": "865bbd91",
    "metadata": {},
    "source": [
-    "## 2️⃣ Register Llama3.1 8B-Instruct into Hopsworks Model Registry\n",
+    "## 2\ufe0f\u20e3 Register Llama3.1 8B-Instruct into Hopsworks Model Registry\n",
     "\n",
     "Once the model files are downloaded from the HuggingFace repository, we can register the models files into the Hopsworks Model Registry."
    ]
@@ -149,7 +149,7 @@
    "cell_type": "markdown",
    "id": "ce98024e",
    "metadata": {},
-   "source": "## 3️⃣ Deploy Llama3.1 8B-Instruct\n\nAfter registering the LLM model into the Model Registry, we can create a deployment that serves it using the vLLM engine with a user-provided configuration (yaml) file."
+   "source": "## 3\ufe0f\u20e3 Deploy Llama3.1 8B-Instruct\n\nAfter registering the LLM model into the Model Registry, we can create a deployment that serves it using the vLLM engine with a user-provided configuration (yaml) file."
   },
   {
    "cell_type": "code",
@@ -194,11 +194,8 @@
     }
    ],
    "source": [
-    "# Upload vllm engine config file for the deployments\n",
-    "\n",
-    "ds_api = project.get_dataset_api()\n",
-    "\n",
-    "path_to_config_file = f\"/Projects/{project.name}/\" + ds_api.upload(\"llama_vllmconfig.yaml\", \"Resources\", overwrite=True)"
+    "# `llama_vllmconfig.yaml` is uploaded to HopsFS automatically by the SDK\n",
+    "# when the deployment is saved; no manual dataset_api.upload step needed."
    ]
   },
   {
@@ -220,7 +217,7 @@
     "llama31_depl = llama31.deploy(\n",
     "    name=\"llama31v2\",\n",
     "    description=\"Llama3.1 8B-Instruct from HuggingFace\",\n",
-    "    config_file=path_to_config_file,\n",
+    "    config_file=\"llama_vllmconfig.yaml\",\n",
     "    resources={\"num_instances\": 1, \"requests\": {\"cores\": 1, \"memory\": 1024*12, \"gpus\": 1}, \"limits\": {\"cores\": 2, \"memory\": 1024*16, \"gpus\": 1}},\n",
     ")"
    ]
@@ -314,7 +311,7 @@
    "id": "d198f9e4",
    "metadata": {},
    "source": [
-    "## 4️⃣ Prompting Llama3.1 8B-Instruct\n",
+    "## 4\ufe0f\u20e3 Prompting Llama3.1 8B-Instruct\n",
     "\n",
     "Once the Llama31 deployment is up and running, we can start sending user prompts to the LLM. You can either use an OpenAI API-compatible client (e.g., openai library) or any other http client."
    ]
@@ -332,7 +329,7 @@
    "id": "68d78906",
    "metadata": {},
    "source": [
-    "### 🟨 Using httpx"
+    "### \ud83d\udfe8 Using httpx"
    ]
   },
   {
@@ -361,7 +358,7 @@
       "Choosing the \"best\" French painter is subjective, as it depends on personal taste and historical context. However, I can provide you with some of the most renowned French painters and highlight their unique contributions to the world of art.\n",
       "\n",
       "1. **Claude Monet** (1840-1926)\n",
-      "Monet is often considered one of the greatest French painters. He was a founding member of the Impressionist movement, which emphasized capturing the fleeting effects of light and color in outdoor settings. Monet's brushstrokes were spontaneous and expressive, and he is famous for his series of water lily paintings (Nymphéas) and his iconic depictions of London's fog-shrouded streets.\n",
+      "Monet is often considered one of the greatest French painters. He was a founding member of the Impressionist movement, which emphasized capturing the fleeting effects of light and color in outdoor settings. Monet's brushstrokes were spontaneous and expressive, and he is famous for his series of water lily paintings (Nymph\u00e9as) and his iconic depictions of London's fog-shrouded streets.\n",
       "\n",
       "Monet's innovative techniques and his focus on light, color, and atmosphere paved the way for future generations of artists. His paintings continue to be celebrated for their beauty, simplicity, and emotional resonance.\n",
       "\n",
@@ -370,21 +367,21 @@
       "\n",
       "Renoir's colorful and expressive portraits, such as \"Dance at Le Moulin de la Galette\" and \"Girl with a Hoop,\" showcase his ability to convey the joy and vitality of life through his art. His influence can be seen in many subsequent artists, from Fauvism to Expressionism.\n",
       "\n",
-      "3. **Jean-Honoré Fragonard** (1732-1806)\n",
+      "3. **Jean-Honor\u00e9 Fragonard** (1732-1806)\n",
       "Fragonard was a Rococo painter known for his delicate and enigmatic depictions of love, nature, and everyday life. His paintings often feature elegant, ornate settings, and his use of pastel colors created a dreamy, ethereal atmosphere.\n",
       "\n",
       "Fragonard's most famous works, such as \"The Happy Accidents of the Swing\" and \"The Stolen Kiss,\" showcase his ability to convey the subtleties of human emotion and the fleeting nature of pleasure. His romantic and idyllic visions of the world have inspired artists for centuries.\n",
       "\n",
-      "4. **Édouard Manet** (1832-1883)\n",
+      "4. **\u00c9douard Manet** (1832-1883)\n",
       "Manet was a pioneer of modern art, and his influence can be seen in many subsequent movements, including Impressionism and Expressionism. His paintings often blurred the lines between fine art and popular culture, incorporating elements of everyday life, fashion, and celebrity.\n",
       "\n",
-      "Manet's most famous works, such as \"Olympia\" and \"A Bar at the Folies-Bergère,\" showcase his ability to challenge traditional notions of beauty and representation. His innovative approach to composition and his use of bold, pure colors paved the way for the development of modern art.\n",
+      "Manet's most famous works, such as \"Olympia\" and \"A Bar at the Folies-Berg\u00e8re,\" showcase his ability to challenge traditional notions of beauty and representation. His innovative approach to composition and his use of bold, pure colors paved the way for the development of modern art.\n",
       "\n",
-      "5. **Paul Cézanne** (1839-1906)\n",
-      "Cézanne was a Post-Impressionist painter who redefined the way artists approached representation and color. His paintings often feature complex, layered perspectives, which\n",
+      "5. **Paul C\u00e9zanne** (1839-1906)\n",
+      "C\u00e9zanne was a Post-Impressionist painter who redefined the way artists approached representation and color. His paintings often feature complex, layered perspectives, which\n",
       " challenge the viewer to engage with the artwork on multiple levels.\n",
       "\n",
-      "Cézanne's most famous works, such as \"Still Life with Apples\" and \"The Bathers,\" showcase his ability to capture the essence of color and form through sheer painterly bravura. His influence can be seen in many subsequent artists, from Fauvism to Cubism.\n",
+      "C\u00e9zanne's most famous works, such as \"Still Life with Apples\" and \"The Bathers,\" showcase his ability to capture the essence of color and form through sheer painterly bravura. His influence can be seen in many subsequent artists, from Fauvism to Cubism.\n",
       "\n",
       "While it's difficult to identify a single \"best\" French painter, these individuals have greatly contributed to the world of art and continue to inspire and influence artists today.\n"
      ]
@@ -432,7 +429,7 @@
       "2. **Use a voice assistant**: If you have a smart speaker or virtual assistant like Siri, Google Assistant, or Alexa, you can ask them to give you the current temperature in Dallas.\n",
       "3. **Check a mobile app**: Download a weather app like Dark Sky, Weather Underground, or The Weather Channel, and search for \"Dallas, TX\" to get the current temperature.\n",
       "\n",
-      "If you want a general idea of the temperature in Dallas, I can tell you that Dallas has a humid subtropical climate, with hot summers and mild winters. The average high temperature in July (Dallas's hottest month) is around 95°F (35°C), while the average high temperature in January (Dallas's coldest month) is around 53°F (12°C).\n"
+      "If you want a general idea of the temperature in Dallas, I can tell you that Dallas has a humid subtropical climate, with hot summers and mild winters. The average high temperature in July (Dallas's hottest month) is around 95\u00b0F (35\u00b0C), while the average high temperature in January (Dallas's coldest month) is around 53\u00b0F (12\u00b0C).\n"
      ]
     }
    ],
@@ -470,7 +467,7 @@
    "id": "fe5d4b7a",
    "metadata": {},
    "source": [
-    "### 🟨 Using OpenAI client"
+    "### \ud83d\udfe8 Using OpenAI client"
    ]
   },
   {
@@ -523,8 +520,8 @@
       "1. **Claude Monet** (1840-1926): A founder of Impressionism, Monet is famous for his captivating landscapes, water lilies, and sunsets. His soft, dreamy brushstrokes revolutionized the art world.\n",
       "2. **Pierre-Auguste Renoir** (1841-1919): A leading figure in Impressionism, Renoir is celebrated for his vibrant depictions of everyday life, often focusing on the beauty of the human body.\n",
       "3. **Henri Matisse** (1869-1954): A pioneer of Fauvism, Matisse is renowned for his bold, colorful works that blended elements of modern art and craftsmanship. His intricate cut-outs and paper sculptures are highly acclaimed.\n",
-      "4. **Paul Cézanne** (1839-1906): A Post-Impressionist master, Cézanne played a crucial role in the development of Cubism. His still-life paintings and landscapes feature innovative uses of color and form.\n",
-      "5. **Jean-Honoré Fragonard** (1732-1806): A Rococo painter, Fragonard is famous for his delicate, intimate works that capture the essence of 18th-century French life. His sensual landscapes and exquisite portraits are highly regarded.\n",
+      "4. **Paul C\u00e9zanne** (1839-1906): A Post-Impressionist master, C\u00e9zanne played a crucial role in the development of Cubism. His still-life paintings and landscapes feature innovative uses of color and form.\n",
+      "5. **Jean-Honor\u00e9 Fragonard** (1732-1806): A Rococo painter, Fragonard is famous for his delicate, intimate works that capture the essence of 18th-century French life. His sensual landscapes and exquisite portraits are highly regarded.\n",
       "\n",
       "These artists have made significant contributions to the history of French art, and their works continue to inspire and awe audiences around the world.\n"
      ]

--- a/api_examples/vllm/mistral-nemo-8b-2407/deploy_mistral-nemo-instruct-2407.ipynb
+++ b/api_examples/vllm/mistral-nemo-8b-2407/deploy_mistral-nemo-instruct-2407.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# A Guide for Mistral NeMo Instruct-2407 on Hopsworks\n",
     "\n",
-    "For details about this Large Language Model (LLM) visit the model page in the HuggingFace repository ➡️ [link](https://huggingface.co/mistralai/Mistral-Nemo-Instruct-2407)"
+    "For details about this Large Language Model (LLM) visit the model page in the HuggingFace repository \u27a1\ufe0f [link](https://huggingface.co/mistralai/Mistral-Nemo-Instruct-2407)"
    ]
   },
   {
@@ -15,7 +15,7 @@
    "id": "ed1b67c8",
    "metadata": {},
    "source": [
-    "### 1️⃣ Download Mistral NeMo Instruct-2407 using the huggingface_hub library\n",
+    "### 1\ufe0f\u20e3 Download Mistral NeMo Instruct-2407 using the huggingface_hub library\n",
     "\n",
     "First, we download the Mistral model files (e.g., weights, configuration files) directly from the HuggingFace repository.\n"
    ]
@@ -56,7 +56,7 @@
    "id": "06633928",
    "metadata": {},
    "source": [
-    "## 2️⃣ Register Mistral NeMo Instruct-2407 into Hopsworks Model Registry\n",
+    "## 2\ufe0f\u20e3 Register Mistral NeMo Instruct-2407 into Hopsworks Model Registry\n",
     "\n",
     "Once the model files are downloaded from the HuggingFace repository, we can register the models files into the Hopsworks Model Registry."
    ]
@@ -149,7 +149,7 @@
    "cell_type": "markdown",
    "id": "55ee2d57",
    "metadata": {},
-   "source": "## 3️⃣ Deploy Mistral NeMo Instruct-2407\n\nAfter registering the LLM model into the Model Registry, we can create a deployment that serves it using the vLLM engine with a user-provided configuration (yaml) file."
+   "source": "## 3\ufe0f\u20e3 Deploy Mistral NeMo Instruct-2407\n\nAfter registering the LLM model into the Model Registry, we can create a deployment that serves it using the vLLM engine with a user-provided configuration (yaml) file."
   },
   {
    "cell_type": "code",
@@ -208,11 +208,8 @@
     }
    ],
    "source": [
-    "# Upload vllm engine config file for the deployments\n",
-    "\n",
-    "ds_api = project.get_dataset_api()\n",
-    "\n",
-    "path_to_config_file = f\"/Projects/{project.name}/\" + ds_api.upload(\"mistral_vllmconfig.yaml\", \"Resources\", overwrite=True)"
+    "# `mistral_vllmconfig.yaml` is uploaded to HopsFS automatically by the SDK\n",
+    "# when the deployment is saved; no manual dataset_api.upload step needed."
    ]
   },
   {
@@ -234,7 +231,7 @@
     "mistral_depl = mistral_nemo.deploy(\n",
     "    name=\"mistralnemo2\",\n",
     "    description=\"Mistral NeMo Instruct-2407 from HuggingFace\",\n",
-    "    config_file=path_to_config_file,\n",
+    "    config_file=\"mistral_vllmconfig.yaml\",\n",
     "    resources={\"num_instances\": 1, \"requests\": {\"cores\": 1, \"memory\": 1024*12, \"gpus\": 1}, \"limits\": {\"cores\": 2, \"memory\": 1024*16, \"gpus\": 1}},\n",
     ")"
    ]
@@ -328,7 +325,7 @@
    "id": "844c04f8",
    "metadata": {},
    "source": [
-    "## 4️⃣ Prompting Mistral NeMo Instruct-2407\n",
+    "## 4\ufe0f\u20e3 Prompting Mistral NeMo Instruct-2407\n",
     "\n",
     "Once the Mistral deployment is up and running, we can start sending user prompts to the LLM. You can either use an OpenAI API-compatible client (e.g., openai library) or any other http client."
    ]
@@ -346,7 +343,7 @@
    "id": "23fd9d4d",
    "metadata": {},
    "source": [
-    "### 🟨 Using httpx"
+    "### \ud83d\udfe8 Using httpx"
    ]
   },
   {
@@ -437,7 +434,7 @@
      "text": [
       "Completion request:  {'model': 'mistralnemo2', 'messages': [{'role': 'user', 'content': 'Hi! How are you doing today?'}, {'role': 'assistant', 'content': \"I'm doing well! How can I help you\"}, {'role': 'user', 'content': 'Can you tell me what the temperate will be in Dallas, in fahrenheit?'}]}\n",
       "2025-01-27 13:18:44,790 INFO: HTTP Request: POST http://51.89.4.22/v1/chat/completions \"HTTP/1.1 200 OK\"\n",
-      "Sure! According to the latest forecast, the temperature in Dallas, TX today will be around 75°F (24°C) during the day, with a low of 57°F (14°C) overnight.\n"
+      "Sure! According to the latest forecast, the temperature in Dallas, TX today will be around 75\u00b0F (24\u00b0C) during the day, with a low of 57\u00b0F (14\u00b0C) overnight.\n"
      ]
     }
    ],
@@ -475,7 +472,7 @@
    "id": "f0122214",
    "metadata": {},
    "source": [
-    "### 🟨 Using OpenAI client"
+    "### \ud83d\udfe8 Using OpenAI client"
    ]
   },
   {
@@ -529,7 +526,7 @@
       "\n",
       "2. **Jacques-Louis David (1748-1825)**: David was a key figure of the Neoclassical style, influential throughout Europe. He played a significant role in the French Revolution, creating powerful, dramatic images that inspired political change. David's works, like \"The Death of Marat\" and \"Oath of the Horatii,\" are renowned for their clarity, symmetry, and emotional impact. His inaccuracies in depiction have led to some controversies, but his influence on Romanticism and Realism is undeniable.\n",
       "\n",
-      "3. **Eugène Delacroix (1798-1863)**: Delacroix is considered one of the founders of the French Romantic school. His expressive, emotional style marked a departure from the more rational Neoclassicism. Delacroix's bold, vibrant colors and dynamic brushwork can be seen in works like \"Liberty Leading the People\" and \"The Death of Sardanapalus.\" His influence can be seen in various 19th-century movements, from Realism to Impressionism and beyond.\n",
+      "3. **Eug\u00e8ne Delacroix (1798-1863)**: Delacroix is considered one of the founders of the French Romantic school. His expressive, emotional style marked a departure from the more rational Neoclassicism. Delacroix's bold, vibrant colors and dynamic brushwork can be seen in works like \"Liberty Leading the People\" and \"The Death of Sardanapalus.\" His influence can be seen in various 19th-century movements, from Realism to Impressionism and beyond.\n",
       "\n",
       "4. **Claude Monet (1840-1926)**: As a founding member of the Impressionist movement, Monet is celebrated for his innovative techniques and dedication to capturing fleeting moments in time and the ever-changing effects of light. Monet's \"Water Lilies\" series, made up of around 250 paintings, is one of the most iconic bodies of work in art history. His influence on modern art, particularly in the realm of landscape painting and abstraction, is profound.\n",
       "\n",
@@ -565,7 +562,7 @@
      "output_type": "stream",
      "text": [
       "2025-01-27 13:19:13,569 INFO: HTTP Request: POST http://51.89.4.22/v1/chat/completions \"HTTP/1.1 200 OK\"\n",
-      "Sure! According to the latest forecast, the temperature in Dallas, Texas will be around 75°F (24°C) today.\n"
+      "Sure! According to the latest forecast, the temperature in Dallas, Texas will be around 75\u00b0F (24\u00b0C) today.\n"
      ]
     }
    ],

--- a/api_examples/vllm/phi-4-mini-instruct/deploy_phi4-mini-instruct.ipynb
+++ b/api_examples/vllm/phi-4-mini-instruct/deploy_phi4-mini-instruct.ipynb
@@ -6,14 +6,14 @@
    "source": [
     "# A Guide for Phi-4-mini-instruct on Hopsworks\n",
     "\n",
-    "For details about this Large Language Model (LLM) visit the model page in the HuggingFace repository ➡️ [link](https://huggingface.co/microsoft/Phi-4-mini-instruct)"
+    "For details about this Large Language Model (LLM) visit the model page in the HuggingFace repository \u27a1\ufe0f [link](https://huggingface.co/microsoft/Phi-4-mini-instruct)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### 1️⃣ Download Phi-4-mini-instruct using the huggingface_hub library\n",
+    "### 1\ufe0f\u20e3 Download Phi-4-mini-instruct using the huggingface_hub library\n",
     "\n",
     "First, we download the Phi-4 model files (e.g., weights, configuration files) directly from the HuggingFace repository.\n"
    ]
@@ -58,7 +58,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 2️⃣ Register Phi-4-mini-instruct into Hopsworks Model Registry\n",
+    "## 2\ufe0f\u20e3 Register Phi-4-mini-instruct into Hopsworks Model Registry\n",
     "\n",
     "Once the model files are downloaded from the HuggingFace repository, we can register the models files into the Hopsworks Model Registry."
    ]
@@ -104,7 +104,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 3️⃣ Deploy Phi-4-mini-instruct\n",
+    "## 3\ufe0f\u20e3 Deploy Phi-4-mini-instruct\n",
     "\n",
     "After registering the LLM model into the Model Registry, we can create a deployment that serves it using the vLLM engine with a user-provided configuration (yaml) file."
    ]
@@ -126,11 +126,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Upload vllm engine config file for the deployments\n",
-    "\n",
-    "ds_api = project.get_dataset_api()\n",
-    "\n",
-    "path_to_config_file = f\"/Projects/{project.name}/\" + ds_api.upload(\"phi_vllmconfig.yaml\", \"Resources\", overwrite=True)"
+    "# `phi_vllmconfig.yaml` is uploaded to HopsFS automatically by the SDK\n",
+    "# when the deployment is saved; no manual dataset_api.upload step needed."
    ]
   },
   {
@@ -142,7 +139,7 @@
     "phi_depl = phi.deploy(\n",
     "    name=\"phi4miniv1\",\n",
     "    description=\"Phi-4-mini-instruct from HuggingFace\",\n",
-    "    config_file=path_to_config_file,\n",
+    "    config_file=\"phi_vllmconfig.yaml\",\n",
     "    resources={\"num_instances\": 1, \"requests\": {\"cores\": 1, \"memory\": 1024*12, \"gpus\": 1}, \"limits\": {\"cores\": 2, \"memory\": 1024*16, \"gpus\": 1}},\n",
     ")"
    ]
@@ -197,7 +194,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 4️⃣ Prompting Phi-4-mini-instruct\n",
+    "## 4\ufe0f\u20e3 Prompting Phi-4-mini-instruct\n",
     "\n",
     "Once the Phi deployment is up and running, we can start sending user prompts to the LLM. You can either use an OpenAI API-compatible client (e.g., openai library) or any other http client."
    ]
@@ -213,7 +210,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### 🟨 Using httpx"
+    "### \ud83d\udfe8 Using httpx"
    ]
   },
   {
@@ -292,7 +289,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### 🟨 Using OpenAI client"
+    "### \ud83d\udfe8 Using OpenAI client"
    ]
   },
   {

--- a/api_examples/vllm/qwen2.5-7b-instruct/deploy_qwen25-7b-instruct.ipynb
+++ b/api_examples/vllm/qwen2.5-7b-instruct/deploy_qwen25-7b-instruct.ipynb
@@ -6,14 +6,14 @@
    "source": [
     "# A Guide for Qwen2.5 7B-Instruct on Hopsworks\n",
     "\n",
-    "For details about this Large Language Model (LLM) visit the model page in the HuggingFace repository ➡️ [link](https://huggingface.co/Qwen/Qwen2.5-7B-Instruct)"
+    "For details about this Large Language Model (LLM) visit the model page in the HuggingFace repository \u27a1\ufe0f [link](https://huggingface.co/Qwen/Qwen2.5-7B-Instruct)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### 1️⃣ Download Qwen2.5 7B-Instruct using the huggingface_hub library\n",
+    "### 1\ufe0f\u20e3 Download Qwen2.5 7B-Instruct using the huggingface_hub library\n",
     "\n",
     "First, we download the Qwen2.5 model files (e.g., weights, configuration files) directly from the HuggingFace repository.\n"
    ]
@@ -58,7 +58,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 2️⃣ Register Qwen2.5 7B-Instruct into Hopsworks Model Registry\n",
+    "## 2\ufe0f\u20e3 Register Qwen2.5 7B-Instruct into Hopsworks Model Registry\n",
     "\n",
     "Once the model files are downloaded from the HuggingFace repository, we can register the models files into the Hopsworks Model Registry."
    ]
@@ -104,7 +104,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 3️⃣ Deploy Qwen2.5 7B-Instruct\n",
+    "## 3\ufe0f\u20e3 Deploy Qwen2.5 7B-Instruct\n",
     "\n",
     "After registering the LLM model into the Model Registry, we can create a deployment that serves it using the vLLM engine with a user-provided configuration (yaml) file."
    ]
@@ -126,11 +126,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Upload vllm engine config file for the deployments\n",
-    "\n",
-    "ds_api = project.get_dataset_api()\n",
-    "\n",
-    "path_to_config_file = f\"/Projects/{project.name}/\" + ds_api.upload(\"qwen_vllmconfig.yaml\", \"Resources\", overwrite=True)"
+    "# `qwen_vllmconfig.yaml` is uploaded to HopsFS automatically by the SDK\n",
+    "# when the deployment is saved; no manual dataset_api.upload step needed."
    ]
   },
   {
@@ -142,7 +139,7 @@
     "qwen_depl = qwen.deploy(\n",
     "    name=\"qwen25v1\",\n",
     "    description=\"Qwen2.5 7B-Instruct from HuggingFace\",\n",
-    "    config_file=path_to_config_file,\n",
+    "    config_file=\"qwen_vllmconfig.yaml\",\n",
     "    resources={\"num_instances\": 1, \"requests\": {\"cores\": 1, \"memory\": 1024*12, \"gpus\": 1}, \"limits\": {\"cores\": 2, \"memory\": 1024*16, \"gpus\": 1}},\n",
     ")"
    ]
@@ -197,7 +194,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 4️⃣ Prompting Qwen2.5 7B-Instruct\n",
+    "## 4\ufe0f\u20e3 Prompting Qwen2.5 7B-Instruct\n",
     "\n",
     "Once the Qwen deployment is up and running, we can start sending user prompts to the LLM. You can either use an OpenAI API-compatible client (e.g., openai library) or any other http client."
    ]
@@ -213,7 +210,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### 🟨 Using httpx"
+    "### \ud83d\udfe8 Using httpx"
    ]
   },
   {
@@ -292,7 +289,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### 🟨 Using OpenAI client"
+    "### \ud83d\udfe8 Using OpenAI client"
    ]
   },
   {

--- a/api_examples/vllm/qwen3-8b/deploy_qwen3-8b.ipynb
+++ b/api_examples/vllm/qwen3-8b/deploy_qwen3-8b.ipynb
@@ -6,14 +6,14 @@
    "source": [
     "# A Guide for Qwen3-8B on Hopsworks\n",
     "\n",
-    "For details about this Large Language Model (LLM) visit the model page in the HuggingFace repository ➡️ [link](https://huggingface.co/Qwen/Qwen3-8B)"
+    "For details about this Large Language Model (LLM) visit the model page in the HuggingFace repository \u27a1\ufe0f [link](https://huggingface.co/Qwen/Qwen3-8B)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### 1️⃣ Download Qwen3-8B using the huggingface_hub library\n",
+    "### 1\ufe0f\u20e3 Download Qwen3-8B using the huggingface_hub library\n",
     "\n",
     "First, we download the Qwen3 model files (e.g., weights, configuration files) directly from the HuggingFace repository.\n"
    ]
@@ -58,7 +58,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 2️⃣ Register Qwen3-8B into Hopsworks Model Registry\n",
+    "## 2\ufe0f\u20e3 Register Qwen3-8B into Hopsworks Model Registry\n",
     "\n",
     "Once the model files are downloaded from the HuggingFace repository, we can register the models files into the Hopsworks Model Registry."
    ]
@@ -104,7 +104,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 3️⃣ Deploy Qwen3-8B\n",
+    "## 3\ufe0f\u20e3 Deploy Qwen3-8B\n",
     "\n",
     "After registering the LLM model into the Model Registry, we can create a deployment that serves it using the vLLM engine with a user-provided configuration (yaml) file."
    ]
@@ -126,11 +126,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Upload vllm engine config file for the deployments\n",
-    "\n",
-    "ds_api = project.get_dataset_api()\n",
-    "\n",
-    "path_to_config_file = f\"/Projects/{project.name}/\" + ds_api.upload(\"qwen3_vllmconfig.yaml\", \"Resources\", overwrite=True)"
+    "# `qwen3_vllmconfig.yaml` is uploaded to HopsFS automatically by the SDK\n",
+    "# when the deployment is saved; no manual dataset_api.upload step needed."
    ]
   },
   {
@@ -142,7 +139,7 @@
     "qwen3_depl = qwen3.deploy(\n",
     "    name=\"qwen3v1\",\n",
     "    description=\"Qwen3-8B from HuggingFace\",\n",
-    "    config_file=path_to_config_file,\n",
+    "    config_file=\"qwen3_vllmconfig.yaml\",\n",
     "    resources={\"num_instances\": 1, \"requests\": {\"cores\": 1, \"memory\": 1024*12, \"gpus\": 1}, \"limits\": {\"cores\": 2, \"memory\": 1024*16, \"gpus\": 1}},\n",
     ")"
    ]
@@ -197,7 +194,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 4️⃣ Prompting Qwen3-8B\n",
+    "## 4\ufe0f\u20e3 Prompting Qwen3-8B\n",
     "\n",
     "Once the Qwen3 deployment is up and running, we can start sending user prompts to the LLM. You can either use an OpenAI API-compatible client (e.g., openai library) or any other http client."
    ]
@@ -213,7 +210,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### 🟨 Using httpx"
+    "### \ud83d\udfe8 Using httpx"
    ]
   },
   {
@@ -292,7 +289,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### 🟨 Using OpenAI client"
+    "### \ud83d\udfe8 Using OpenAI client"
    ]
   },
   {

--- a/benchmarks/online-inference-pipeline/2_fraud_online_training_pipeline.ipynb
+++ b/benchmarks/online-inference-pipeline/2_fraud_online_training_pipeline.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## <span style='color:#ff5f27'> 📝 Imports"
+    "## <span style='color:#ff5f27'> \ud83d\udcdd Imports"
    ]
   },
   {
@@ -35,7 +35,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## <span style=\"color:#ff5f27;\"> 📡 Connecting to Hopsworks Feature Store </span>"
+    "## <span style=\"color:#ff5f27;\"> \ud83d\udce1 Connecting to Hopsworks Feature Store </span>"
    ]
   },
   {
@@ -74,7 +74,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## <span style=\"color:#ff5f27;\"> 🔪 Feature Selection </span>"
+    "## <span style=\"color:#ff5f27;\"> \ud83d\udd2a Feature Selection </span>"
    ]
   },
   {
@@ -127,7 +127,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### <span style=\"color:#ff5f27;\"> 🤖 Transformation Functions </span>\n",
+    "### <span style=\"color:#ff5f27;\"> \ud83e\udd16 Transformation Functions </span>\n",
     "\n",
     "Manually creating `label_encoder` as a python UDF to get optimal performance during online inference. \n",
     "\n",
@@ -172,7 +172,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## <span style=\"color:#ff5f27;\"> ⚙️ Feature View Creation </span>"
+    "## <span style=\"color:#ff5f27;\"> \u2699\ufe0f Feature View Creation </span>"
    ]
   },
   {
@@ -204,7 +204,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## <span style=\"color:#ff5f27;\"> 🏋️ Training Dataset </span>"
+    "## <span style=\"color:#ff5f27;\"> \ud83c\udfcb\ufe0f Training Dataset </span>"
    ]
   },
   {
@@ -281,7 +281,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## <span style=\"color:#ff5f27;\"> 🧬 Modeling</span>"
+    "## <span style=\"color:#ff5f27;\"> \ud83e\uddec Modeling</span>"
    ]
   },
   {
@@ -462,7 +462,7 @@
        "\n",
        "#sk-container-id-1 label.sk-toggleable__label-arrow:before {\n",
        "  /* Arrow on the left of the label */\n",
-       "  content: \"▸\";\n",
+       "  content: \"\u25b8\";\n",
        "  float: left;\n",
        "  margin-right: 0.25em;\n",
        "  color: var(--sklearn-color-icon);\n",
@@ -507,7 +507,7 @@
        "}\n",
        "\n",
        "#sk-container-id-1 input.sk-toggleable__control:checked~label.sk-toggleable__label-arrow:before {\n",
-       "  content: \"▾\";\n",
+       "  content: \"\u25be\";\n",
        "}\n",
        "\n",
        "/* Pipeline/ColumnTransformer-specific style */\n",
@@ -1337,7 +1337,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## <span style=\"color:#ff5f27;\">📝 Register model</span>"
+    "## <span style=\"color:#ff5f27;\">\ud83d\udcdd Register model</span>"
    ]
   },
   {
@@ -1437,7 +1437,7 @@
        "version_minor": 0
       },
       "text/plain": [
-       "Uploading /Users/manu/Desktop/HopsWorks/bechmarking_hopsworks/fraud_online_model/xgboost_fraud_online_model.pk…"
+       "Uploading /Users/manu/Desktop/HopsWorks/bechmarking_hopsworks/fraud_online_model/xgboost_fraud_online_model.pk\u2026"
       ]
      },
      "metadata": {},
@@ -1451,7 +1451,7 @@
        "version_minor": 0
       },
       "text/plain": [
-       "Uploading /Users/manu/Desktop/HopsWorks/bechmarking_hopsworks/fraud_online_model/images/confusion_matrix.png: …"
+       "Uploading /Users/manu/Desktop/HopsWorks/bechmarking_hopsworks/fraud_online_model/images/confusion_matrix.png: \u2026"
       ]
      },
      "metadata": {},
@@ -1465,7 +1465,7 @@
        "version_minor": 0
       },
       "text/plain": [
-       "Uploading /Users/manu/Desktop/HopsWorks/bechmarking_hopsworks/input_example.json: 0.000%|          | 0/18 elap…"
+       "Uploading /Users/manu/Desktop/HopsWorks/bechmarking_hopsworks/input_example.json: 0.000%|          | 0/18 elap\u2026"
       ]
      },
      "metadata": {},
@@ -1479,7 +1479,7 @@
        "version_minor": 0
       },
       "text/plain": [
-       "Uploading /Users/manu/Desktop/HopsWorks/bechmarking_hopsworks/model_schema.json: 0.000%|          | 0/664 elap…"
+       "Uploading /Users/manu/Desktop/HopsWorks/bechmarking_hopsworks/model_schema.json: 0.000%|          | 0/664 elap\u2026"
       ]
      },
      "metadata": {},
@@ -1534,14 +1534,14 @@
     "tags": []
    },
    "source": [
-    "## <a class=\"anchor\" id=\"1.5_bullet\" style=\"color:#ff5f27\"> 🚀 Model Deployment</a>"
+    "## <a class=\"anchor\" id=\"1.5_bullet\" style=\"color:#ff5f27\"> \ud83d\ude80 Model Deployment</a>"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### <span style=\"color:#ff5f27;\">📎 Predictor script for Python models</span>\n",
+    "### <span style=\"color:#ff5f27;\">\ud83d\udcce Predictor script for Python models</span>\n",
     "\n",
     "The predictor script to use the [online feature store REST APIs](https://docs.hopsworks.ai/latest/user_guides/fs/feature_view/feature-server/) and an aysnc `predict` function to allow higher IO-Bound parallelism.\n",
     "\n",
@@ -1654,7 +1654,7 @@
        "version_minor": 0
       },
       "text/plain": [
-       "Uploading /Users/manu/Desktop/HopsWorks/bechmarking_hopsworks/predict_rdrs_async.py: 0.000%|          | 0/2733…"
+       "Uploading /Users/manu/Desktop/HopsWorks/bechmarking_hopsworks/predict_rdrs_async.py: 0.000%|          | 0/2733\u2026"
       ]
      },
      "metadata": {},
@@ -1662,17 +1662,8 @@
     }
    ],
    "source": [
-    "# Get the dataset API for the current project\n",
-    "dataset_api = project.get_dataset_api()\n",
-    "\n",
-    "# Specify the local file path of the Python script to be uploaded\n",
-    "local_script_path_async_rdrs = \"predict_rdrs_async.py\"\n",
-    "\n",
-    "# Upload the Python script to the \"Models\", and overwrite if it already exists\\\n",
-    "uploaded_file_path_async_rdrs = dataset_api.upload(local_script_path_async_rdrs, \"Models\", overwrite=True)\n",
-    "\n",
-    "# Create the full path to the uploaded script for future reference\n",
-    "predictor_script_path_async_rdrs = os.path.join(\"/Projects\", project.name, uploaded_file_path_async_rdrs)"
+    "# `predict_rdrs_async.py` is uploaded to HopsFS automatically by the SDK\n",
+    "# when the deployment is saved; no manual dataset_api.upload step needed."
    ]
   },
   {
@@ -1695,7 +1686,7 @@
        "version_minor": 0
       },
       "text/plain": [
-       "Uploading /Users/manu/Desktop/HopsWorks/bechmarking_hopsworks/requirements-deployment.txt: 0.000%|          | …"
+       "Uploading /Users/manu/Desktop/HopsWorks/bechmarking_hopsworks/requirements-deployment.txt: 0.000%|          | \u2026"
       ]
      },
      "metadata": {},
@@ -1752,7 +1743,7 @@
     "# Deploy the fraud model\n",
     "deployment_async_rdrs = fraud_model.deploy(\n",
     "    name=\"deploymentasyncrdrs\",  # Specify a name for the deployment\n",
-    "    script_file=predictor_script_path_async_rdrs,  # Provide the path to the Python script for prediction\n",
+    "    script_file=\"predict_rdrs_async.py\",  # Local path; SDK auto-uploads on save\n",
     "    resources={'num_instances': 1, 'requests': {'cores': 1}, 'limits': {'cores': 1}},\n",
     "    environment=deployment_env.name\n",
     ")"

--- a/integrations/neo4j/2_training_pipeline.ipynb
+++ b/integrations/neo4j/2_training_pipeline.ipynb
@@ -8,7 +8,7 @@
     "\n",
     "<span style=\"font-width:bold; font-size: 1.4rem;\"> This notebook explains how to read from a feature group and create training dataset within the feature store. You will train a model on the created training dataset. You will train your model using TensorFlow, although it could just as well be trained with other machine learning frameworks such as Scikit-learn, Keras, and PyTorch. You will also see some of the exploration that can be done in Hopsworks, notably the search functions and the lineage.</span>\n",
     "\n",
-    "## **🗒️ This notebook is divided into the following steps:** \n",
+    "## **\ud83d\uddd2\ufe0f This notebook is divided into the following steps:** \n",
     "\n",
     "1. **Feature Selection**: Select the features you want to train your model on.\n",
     "2. **Feature Transformation**: How the features should be preprocessed.\n",
@@ -24,7 +24,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## <span style='color:#ff5f27'> 📝 Imports"
+    "## <span style='color:#ff5f27'> \ud83d\udcdd Imports"
    ]
   },
   {
@@ -46,7 +46,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## <span style=\"color:#ff5f27;\"> 📡 Connecting to Hopsworks Feature Store </span>"
+    "## <span style=\"color:#ff5f27;\"> \ud83d\udce1 Connecting to Hopsworks Feature Store </span>"
    ]
   },
   {
@@ -66,7 +66,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## <span style=\"color:#ff5f27;\"> 🔪 Feature Selection </span>\n",
+    "## <span style=\"color:#ff5f27;\"> \ud83d\udd2a Feature Selection </span>\n",
     "\n",
     "You start by selecting all the features you want to include for model training/inference."
    ]
@@ -132,7 +132,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### <span style=\"color:#ff5f27;\"> 🤖 Transformation Functions </span>\n",
+    "### <span style=\"color:#ff5f27;\"> \ud83e\udd16 Transformation Functions </span>\n",
     "\n",
     "Transformation functions are a mathematical mapping of input data that may be stateful - requiring statistics from the partent feature view (such as number of instances of a category, or mean value of a numerical feature)\n",
     "\n",
@@ -165,7 +165,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## <span style=\"color:#ff5f27;\"> ⚙️ Feature View Creation </span>\n",
+    "## <span style=\"color:#ff5f27;\"> \u2699\ufe0f Feature View Creation </span>\n",
     "\n",
     "In Hopsworks, you write features to feature groups (where the features are stored) and you read features from feature views. A feature view is a logical view over features, stored in feature groups, and a feature view typically contains the features used by a specific model. This way, feature views enable features, stored in different feature groups, to be reused across many different models. The Feature Views allows schema in form of a query with filters, define a model target feature/label and additional transformation functions.\n",
     "In order to create a Feature View we may use `fs.create_feature_view()`"
@@ -190,7 +190,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## <span style=\"color:#ff5f27;\"> 🏋️ Training Dataset Creation</span>\n",
+    "## <span style=\"color:#ff5f27;\"> \ud83c\udfcb\ufe0f Training Dataset Creation</span>\n",
     "\n",
     "In Hopsworks training data is a query where the projection (set of features) is determined by the parent FeatureView with an optional snapshot on disk of the data returned by the query.\n",
     "\n",
@@ -250,7 +250,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# <span style=\"color:#ff5f27;\">🤖 Model Building</span>\n"
+    "# <span style=\"color:#ff5f27;\">\ud83e\udd16 Model Building</span>\n"
    ]
   },
   {
@@ -363,7 +363,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## <span style=\"color:#ff5f27;\"> 🏃 Train Model</span>\n",
+    "## <span style=\"color:#ff5f27;\"> \ud83c\udfc3 Train Model</span>\n",
     "\n",
     "Next we'll train a model. Here, we set the class weight of the positive class to be twice as big as the negative class."
    ]
@@ -372,7 +372,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## <span style=\"color:#ff5f27;\">🧬 Model architecture</span>\n",
+    "## <span style=\"color:#ff5f27;\">\ud83e\uddec Model architecture</span>\n",
     "\n",
     "Key components:\n",
     "\n",
@@ -442,7 +442,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## <span style=\"color:#ff5f27;\">📝 Register model</span>\n",
+    "## <span style=\"color:#ff5f27;\">\ud83d\udcdd Register model</span>\n",
     "\n",
     "One of the features in Hopsworks is the model registry. This is where we can store different versions of models and compare their performance. Models from the registry can then be served as API endpoints."
    ]
@@ -488,7 +488,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## <span style=\"color:#ff5f27;\"> 🚀 Model Deployment</span>\n"
+    "## <span style=\"color:#ff5f27;\"> \ud83d\ude80 Model Deployment</span>\n"
    ]
   },
   {
@@ -577,26 +577,10 @@
    "source": [
     "from hsml.transformer import Transformer\n",
     "\n",
-    "# Get the dataset API from the project\n",
-    "dataset_api = project.get_dataset_api()\n",
-    "\n",
-    "# Upload the transformer script file to the \"Models\" dataset\n",
-    "uploaded_file_path = dataset_api.upload(\n",
-    "    \"aml_model_transformer.py\",   # Name of the script file\n",
-    "    \"Resources\",                     # Destination folder in the dataset\n",
-    "    overwrite=True,               # Overwrite the file if it already exists\n",
-    ")\n",
-    "\n",
-    "# Construct the full path to the uploaded transformer script file\n",
-    "transformer_script_path = os.path.join(\n",
-    "    \"/Projects\", \n",
-    "    project.name, \n",
-    "    uploaded_file_path,\n",
-    ")\n",
-    "\n",
-    "# Create a Transformer object using the uploaded script\n",
+    "# `aml_model_transformer.py` is uploaded to HopsFS automatically by the\n",
+    "# SDK when the deployment is saved; no manual dataset_api.upload step needed.\n",
     "transformer_script = Transformer(\n",
-    "    script_file=transformer_script_path,\n",
+    "    script_file=\"aml_model_transformer.py\",\n",
     ")"
    ]
   },
@@ -682,7 +666,7 @@
    "metadata": {},
    "source": [
     "---\n",
-    "## <span style=\"color:#ff5f27;\"> ⏭️ Next: Part 03: Online Inference </span>\n",
+    "## <span style=\"color:#ff5f27;\"> \u23ed\ufe0f Next: Part 03: Online Inference </span>\n",
     "    \n",
     "In the next notebook you will use your deployment for online inference."
    ]

--- a/integrations/pyspark_streaming/2_training_pipeline.ipynb
+++ b/integrations/pyspark_streaming/2_training_pipeline.ipynb
@@ -8,7 +8,7 @@
     "\n",
     "<span style=\"font-width:bold; font-size: 1.4rem;\">This notebook explains how to read from a feature group, create training dataset within the feature store, train a model and save it to model registry.</span>\n",
     "\n",
-    "## 🗒️ This notebook is divided into the following sections:\n",
+    "## \ud83d\uddd2\ufe0f This notebook is divided into the following sections:\n",
     "\n",
     "1. Fetch Feature Groups.\n",
     "2. Define Transformation functions.\n",
@@ -24,7 +24,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## <span style='color:#ff5f27'> 📝 Imports"
+    "## <span style='color:#ff5f27'> \ud83d\udcdd Imports"
    ]
   },
   {
@@ -64,7 +64,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## <span style=\"color:#ff5f27;\"> 📡 Connecting to Hopsworks Feature Store </span>"
+    "## <span style=\"color:#ff5f27;\"> \ud83d\udce1 Connecting to Hopsworks Feature Store </span>"
    ]
   },
   {
@@ -84,7 +84,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### <span style=\"color:#ff5f27;\"> 🔪 Feature Selection </span>\n",
+    "### <span style=\"color:#ff5f27;\"> \ud83d\udd2a Feature Selection </span>\n",
     "\n",
     "You will start by selecting all the features you want to include for model training/inference."
    ]
@@ -145,7 +145,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### <span style=\"color:#ff5f27;\"> 🤖 Transformation Functions </span>\n",
+    "### <span style=\"color:#ff5f27;\"> \ud83e\udd16 Transformation Functions </span>\n",
     "\n",
     "\n",
     "You will preprocess our data using *min-max scaling* on numerical features and *label encoding* on categorical features. To do this you simply define a mapping between our features and transformation functions. This ensures that transformation functions such as *min-max scaling* are fitted only on the training data (and not the validation/test data), which ensures that there is no data leakage."
@@ -170,7 +170,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## <span style=\"color:#ff5f27;\"> ⚙️ Feature View Creation </span>\n",
+    "## <span style=\"color:#ff5f27;\"> \u2699\ufe0f Feature View Creation </span>\n",
     "\n",
     "The Feature Views allows schema in form of a query with filters, define a model target feature/label and additional transformation functions.\n",
     "In order to create a Feature View you may use `fs.create_feature_view()`. Here we try first to get the feature view, and if we can't an exception is thrown and we create the feature view."
@@ -205,7 +205,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## <span style=\"color:#ff5f27;\"> 🏋️ Training Dataset Creation</span>\n",
+    "## <span style=\"color:#ff5f27;\"> \ud83c\udfcb\ufe0f Training Dataset Creation</span>\n",
     "\n",
     "In Hopsworks training data is a query where the projection (set of features) is determined by the parent FeatureView with an optional snapshot on disk of the data returned by the query.\n",
     "\n",
@@ -297,7 +297,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## <span style=\"color:#ff5f27;\"> 🧬 Modeling</span>\n",
+    "## <span style=\"color:#ff5f27;\"> \ud83e\uddec Modeling</span>\n",
     "\n",
     "Next you will train a model. Here, you set larger class weight for the positive class."
    ]
@@ -386,7 +386,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## <span style=\"color:#ff5f27;\">📝 Register model</span>\n",
+    "## <span style=\"color:#ff5f27;\">\ud83d\udcdd Register model</span>\n",
     "\n",
     "One of the features in Hopsworks is the model registry. This is where we can store different versions of models and compare their performance. Models from the registry can then be served as API endpoints."
    ]
@@ -437,7 +437,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## <a class=\"anchor\" id=\"1.5_bullet\" style=\"color:#ff5f27\"> 🚀 Model Deployment</a>\n",
+    "## <a class=\"anchor\" id=\"1.5_bullet\" style=\"color:#ff5f27\"> \ud83d\ude80 Model Deployment</a>\n",
     "\n",
     "\n",
     "### About Model Serving\n",
@@ -450,7 +450,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### <span style=\"color:#ff5f27;\">📎 Predictor script for Python models</span>\n",
+    "### <span style=\"color:#ff5f27;\">\ud83d\udcce Predictor script for Python models</span>\n",
     "\n",
     "\n",
     "Scikit-learn and XGBoost models are deployed as Python models, in which case you need to provide a **Predict** class that implements the **predict** method. The **predict()** method invokes the model on the inputs and returns the prediction as a list.\n",
@@ -512,17 +512,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Get the dataset API for the current project\n",
-    "dataset_api = project.get_dataset_api()\n",
-    "\n",
-    "# Specify the local file path of the Python script to be uploaded\n",
-    "local_script_path = \"predict_example.py\"\n",
-    "\n",
-    "# Upload the Python script to the \"Models\", and overwrite if it already exists\n",
-    "uploaded_file_path = dataset_api.upload(local_script_path, \"Models\", overwrite=True)\n",
-    "\n",
-    "# Create the full path to the uploaded script for future reference\n",
-    "predictor_script_path = os.path.join(\"/Projects\", project.name, uploaded_file_path)"
+    "# `predict_example.py` is uploaded to HopsFS automatically by the SDK\n",
+    "# when the deployment is saved; no manual dataset_api.upload step needed."
    ]
   },
   {
@@ -542,7 +533,7 @@
     "# Deploy the fraud model\n",
     "deployment = fraud_model.deploy(\n",
     "    name=\"fraudonlinemodeldeployment\",  # Specify a name for the deployment\n",
-    "    script_file=predictor_script_path,  # Provide the path to the Python script for prediction\n",
+    "    script_file=\"predict_example.py\",  # Local path; SDK auto-uploads on save\n",
     ")"
    ]
   },
@@ -629,7 +620,7 @@
    "metadata": {},
    "source": [
     "---\n",
-    "## <span style=\"color:#ff5f27;\">⏭️ **Next:** Part 03: Online Inference</span>\n",
+    "## <span style=\"color:#ff5f27;\">\u23ed\ufe0f **Next:** Part 03: Online Inference</span>\n",
     "\n",
     "In the following notebook you will use your model for online inference.\n"
    ]

--- a/llm-ai-systems/recommender-system/5_create_deployments.ipynb
+++ b/llm-ai-systems/recommender-system/5_create_deployments.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## <span style=\"color:#ff5f27\">👨🏻‍🏫 Create Deployment </span>\n",
+    "## <span style=\"color:#ff5f27\">\ud83d\udc68\ud83c\udffb\u200d\ud83c\udfeb Create Deployment </span>\n",
     "\n",
     "In this notebook, you'll create a deployment for your recommendation system.\n"
    ]
@@ -25,7 +25,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## <span style=\"color:#ff5f27\">📝 Imports </span>"
+    "## <span style=\"color:#ff5f27\">\ud83d\udcdd Imports </span>"
    ]
   },
   {
@@ -41,7 +41,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## <span style=\"color:#ff5f27\">🔮 Connect to Hopsworks Feature Store </span>"
+    "## <span style=\"color:#ff5f27\">\ud83d\udd2e Connect to Hopsworks Feature Store </span>"
    ]
   },
   {
@@ -86,9 +86,9 @@
     "tags": []
    },
    "source": [
-    "## <span style=\"color:#ff5f27\">🚀 Recommender Model Deployment </span>\n",
+    "## <span style=\"color:#ff5f27\">\ud83d\ude80 Recommender Model Deployment </span>\n",
     "\n",
-    "📝 Includes the next steps:\n",
+    "\ud83d\udcdd Includes the next steps:\n",
     "1. Generate query embedding from customer data.\n",
     "2. Find the closest candidate items to customer embedding using similarity search.\n",
     "3. Filter out items the customer has already bought.\n",
@@ -246,7 +246,7 @@
     "            for item_id in item_id_list\n",
     "        ]\n",
     "\n",
-    "        logging.info(\"✅ Articles Data Retrieved!\")\n",
+    "        logging.info(\"\u2705 Articles Data Retrieved!\")\n",
     "\n",
     "        articles_df = pd.DataFrame(\n",
     "            data=articles_data,\n",
@@ -260,7 +260,7 @@
     "            how=\"inner\",\n",
     "        )\n",
     "\n",
-    "        logging.info(\"✅ Inputs are almost ready!\")\n",
+    "        logging.info(\"\u2705 Inputs are almost ready!\")\n",
     "\n",
     "        # Add customer features\n",
     "        customer_features = self.customer_fv.get_feature_vector(\n",
@@ -275,7 +275,7 @@
     "        # Select only the features required by the ranking model\n",
     "        ranking_model_inputs = ranking_model_inputs[self.ranking_model_feature_names]\n",
     "\n",
-    "        logging.info(\"✅ Inputs are ready!\")\n",
+    "        logging.info(\"\u2705 Inputs are ready!\")\n",
     "\n",
     "        features = ranking_model_inputs.values.tolist()\n",
     "        article_ids = item_id_list\n",
@@ -286,7 +286,7 @@
     "        # Log the extracted article ids\n",
     "        logging.info(f'Article IDs: {article_ids}')\n",
     "        \n",
-    "        logging.info(f\"🚀 Predicting...\")\n",
+    "        logging.info(f\"\ud83d\ude80 Predicting...\")\n",
     "\n",
     "        # Predict probabilities for the positive class\n",
     "        scores = self.model.predict_proba(features).tolist()\n",
@@ -294,7 +294,7 @@
     "        # Get scores of positive class\n",
     "        scores = np.asarray(scores)[:,1].tolist() \n",
     "\n",
-    "        logging.info(\"✅ Predictions are ready!\")\n",
+    "        logging.info(\"\u2705 Predictions are ready!\")\n",
     "\n",
     "        # Merge prediction scores and corresponding article IDs into a list of tuples\n",
     "        ranking = list(zip(scores, article_ids))\n",
@@ -314,19 +314,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Copy transformer file into Hopsworks File System\n",
-    "uploaded_file_path = dataset_api.upload(\n",
-    "    \"recommender_transformer.py\", \n",
-    "    \"Models\", \n",
-    "    overwrite=True,\n",
-    ")\n",
-    "\n",
-    "# Construct the path to the uploaded script\n",
-    "transformer_script_path = os.path.join(\n",
-    "    \"/Projects\", \n",
-    "    project.name, \n",
-    "    uploaded_file_path,\n",
-    ")"
+    "# `recommender_transformer.py` is uploaded to HopsFS automatically by the\n",
+    "# SDK when the deployment is saved; no manual dataset_api.upload step needed."
    ]
   },
   {
@@ -341,7 +330,7 @@
     "\n",
     "# Define transformer\n",
     "recommender_transformer=Transformer(\n",
-    "    script_file=transformer_script_path, \n",
+    "    script_file=\"recommender_transformer.py\", \n",
     "    resources={\"num_instances\": 0},\n",
     ")\n",
     "\n",
@@ -435,7 +424,7 @@
     "\n",
     "# Calculate and print the execution time\n",
     "notebook_execution_time = notebook_end_time - notebook_start_time\n",
-    "print(f\"⌛️ Notebook Execution time: {notebook_execution_time:.2f} seconds\")"
+    "print(f\"\u231b\ufe0f Notebook Execution time: {notebook_execution_time:.2f} seconds\")"
    ]
   },
   {

--- a/quickstart.ipynb
+++ b/quickstart.ipynb
@@ -44,7 +44,7 @@
     "id": "NpwpPe1wxQ5M"
    },
    "source": [
-    "## <span style=\"color:#ff5f27;\"> 💽 Loading the Data </span>\n",
+    "## <span style=\"color:#ff5f27;\"> \ud83d\udcbd Loading the Data </span>\n",
     "\n",
     "The data you will use comes from three different CSV files:\n",
     "\n",
@@ -129,7 +129,7 @@
     "id": "HPq2qUtNxjaM"
    },
    "source": [
-    "## <span style=\"color:#ff5f27;\"> 🛠️ Feature Engineering </span>\n",
+    "## <span style=\"color:#ff5f27;\"> \ud83d\udee0\ufe0f Feature Engineering </span>\n",
     "\n",
     "Fraudulent transactions can differ from regular ones in many different ways. Typical red flags would for instance be a large transaction volume/frequency in the span of a few hours. It could also be the case that elderly people in particular are targeted by fraudsters. To facilitate model learning, we will create additional features based on these patterns. In particular, we will create two types of features:\n",
     "\n",
@@ -298,7 +298,7 @@
     "id": "yB90r9qszLe2"
    },
    "source": [
-    "## <span style=\"color:#ff5f27;\"> 🪄 Creating Feature Groups </span>\n",
+    "## <span style=\"color:#ff5f27;\"> \ud83e\ude84 Creating Feature Groups </span>\n",
     "\n",
     "A feature group can be seen as a collection of conceptually related features that are computed together at the same cadence. In your case, you will create a feature group for the transaction data and a feature group for the windowed aggregations on the transaction data. Both will have `tid` as primary key, which will allow you to join them together to  create training data in a follow-on tutorial.\n",
     "\n",
@@ -465,7 +465,7 @@
     "tags": []
    },
    "source": [
-    "### <span style=\"color:#ff5f27;\"> 🔪 Feature Selection </span>\n",
+    "### <span style=\"color:#ff5f27;\"> \ud83d\udd2a Feature Selection </span>\n",
     "\n",
     "You will start by selecting all the features you want to include for model training/inference."
    ]
@@ -509,7 +509,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### <span style=\"color:#ff5f27;\"> 🤖 Transformation Functions </span>\n",
+    "### <span style=\"color:#ff5f27;\"> \ud83e\udd16 Transformation Functions </span>\n",
     "\n",
     "\n",
     "You will preprocess our data using *min-max scaling* on numerical features and *label encoding* on categorical features. To do this you simply define a mapping between our features and transformation functions. This ensures that transformation functions such as *min-max scaling* are fitted only on the training data (and not the validation/test data), which ensures that there is no data leakage."
@@ -534,7 +534,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## <span style=\"color:#ff5f27;\"> ⚙️ Feature View Creation </span>\n",
+    "## <span style=\"color:#ff5f27;\"> \u2699\ufe0f Feature View Creation </span>\n",
     "\n",
     "The Feature View is the collection of features (from feature groups) and transformation functions used to train models and serve precomputed features to deployed models.\n",
     "\n",
@@ -575,7 +575,7 @@
     "tags": []
    },
    "source": [
-    "## <span style=\"color:#ff5f27;\"> 🏋️ Training Dataset Creation</span>\n",
+    "## <span style=\"color:#ff5f27;\"> \ud83c\udfcb\ufe0f Training Dataset Creation</span>\n",
     "\n",
     "In Hopsworks training data is a query where the projection (set of features) is determined by the parent FeatureView with an optional snapshot on disk of the data returned by the query.\n",
     "\n",
@@ -668,7 +668,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## <span style=\"color:#ff5f27;\"> 🧬 Modeling</span>\n",
+    "## <span style=\"color:#ff5f27;\"> \ud83e\uddec Modeling</span>\n",
     "\n",
     "Next you will train a model. Here, you set larger class weight for the positive class."
    ]
@@ -734,7 +734,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## <span style=\"color:#ff5f27;\">📝 Register model</span>\n",
+    "## <span style=\"color:#ff5f27;\">\ud83d\udcdd Register model</span>\n",
     "\n",
     "One of the features in Hopsworks is the model registry. This is where we can store different versions of models and compare their performance. Models from the registry can then be served as API endpoints."
    ]
@@ -831,7 +831,7 @@
     "tags": []
    },
    "source": [
-    "## <a class=\"anchor\" id=\"1.5_bullet\" style=\"color:#ff5f27\"> 🚀 Model Deployment</a>\n",
+    "## <a class=\"anchor\" id=\"1.5_bullet\" style=\"color:#ff5f27\"> \ud83d\ude80 Model Deployment</a>\n",
     "\n",
     "\n",
     "### About Model Serving\n",
@@ -844,7 +844,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### <span style=\"color:#ff5f27;\">📎 Predictor script for Python models</span>\n",
+    "### <span style=\"color:#ff5f27;\">\ud83d\udcce Predictor script for Python models</span>\n",
     "\n",
     "\n",
     "Scikit-learn and XGBoost models are deployed as Python models, in which case you need to provide a **Predict** class that implements the **predict** method. The **predict()** method invokes the model on the inputs and returns the prediction as a list.\n",
@@ -909,21 +909,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Get the dataset API from the project\n",
-    "dataset_api = project.get_dataset_api()\n",
-    "\n",
-    "# Specify the file to upload (\"predict_example.py\") to the \"Models\" directory, and allow overwriting\n",
-    "uploaded_file_path = dataset_api.upload(\"predict_example.py\", \"Models\", overwrite=True)\n",
-    "\n",
-    "# Construct the full path to the uploaded predictor script\n",
-    "predictor_script_path = os.path.join(\"/Projects\", project.name, uploaded_file_path)"
+    "# `predict_example.py` is uploaded to HopsFS automatically by the SDK\n",
+    "# when the deployment is saved; no manual dataset_api.upload step needed."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### <span style=\"color:#ff5f27;\">👩🏻‍🔬 Create the deployment</span>\n",
+    "### <span style=\"color:#ff5f27;\">\ud83d\udc69\ud83c\udffb\u200d\ud83d\udd2c Create the deployment</span>\n",
     "\n",
     "Here, you fetch the model you want from the model registry and define a configuration for the deployment. For the configuration, you need to specify the serving type (default or KFserving)."
    ]
@@ -937,7 +931,7 @@
     "# Deploy the fraud model\n",
     "deployment = fraud_model.deploy(\n",
     "    name=\"fraud\",                       # Specify the deployment name\n",
-    "    script_file=predictor_script_path,  # Provide the path to the predictor script\n",
+    "    script_file=\"predict_example.py\",  # Local path; SDK auto-uploads on save\n",
     ")"
    ]
   },
@@ -991,7 +985,7 @@
     "id": "QKCTKfcaimxo"
    },
    "source": [
-    "## <span style=\"color:#ff5f27;\"> 📡 Test your Model with an Inference Request </span>\n",
+    "## <span style=\"color:#ff5f27;\"> \ud83d\udce1 Test your Model with an Inference Request </span>\n",
     "\n",
     "Finally you can start making predictions with your model! \n",
     "\n",
@@ -1022,7 +1016,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## <span style=\"color:#ff5f27;\"> 👾 Try out your Model Interactively </span> \n",
+    "## <span style=\"color:#ff5f27;\"> \ud83d\udc7e Try out your Model Interactively </span> \n",
     "\n",
     "We will build a user interface with Gradio to allow you to enter a credit card category and amount to see if the credit card transaction will be marked as suspected of fraud or not."
    ]
@@ -1084,14 +1078,14 @@
     "id": "HmwNUVbHjO5I"
    },
    "source": [
-    "## <span style=\"color:#ff5f27;\"> 🥳 Next Steps</span>\n",
+    "## <span style=\"color:#ff5f27;\"> \ud83e\udd73 Next Steps</span>\n",
     "\n",
     "Congratulations you've now completed the quickstart example for Managed Hopsworks.\n",
     "\n",
     "\n",
-    "Check out our other tutorials on ➡ https://github.com/logicalclocks/hopsworks-tutorials\n",
+    "Check out our other tutorials on \u27a1 https://github.com/logicalclocks/hopsworks-tutorials\n",
     "\n",
-    "Or documentation at ➡ https://docs.hopsworks.ai"
+    "Or documentation at \u27a1 https://docs.hopsworks.ai"
    ]
   }
  ],
@@ -1315,7 +1309,7 @@
       "description": "",
       "description_tooltip": null,
       "layout": "IPY_MODEL_a26b3a1aa96f4eeaaad89d4d662fa010",
-      "placeholder": "​",
+      "placeholder": "\u200b",
       "style": "IPY_MODEL_ed9e0fc80c9e483cb7aafad007b57ea0",
       "value": "Deployment is running: 100%"
      }
@@ -1351,7 +1345,7 @@
       "description": "",
       "description_tooltip": null,
       "layout": "IPY_MODEL_d1c010a576d94f8bbcc6f535741f514b",
-      "placeholder": "​",
+      "placeholder": "\u200b",
       "style": "IPY_MODEL_5fd0bd75549a47ae8a3042f1e0c61ba5",
       "value": "Model export complete: 100%"
      }
@@ -1439,7 +1433,7 @@
       "description": "",
       "description_tooltip": null,
       "layout": "IPY_MODEL_192f266700894002b24eeff9b2136db3",
-      "placeholder": "​",
+      "placeholder": "\u200b",
       "style": "IPY_MODEL_1b7c2a4d212646239113f831eeafc1cd",
       "value": " 6/6 [00:25&lt;00:00,  5.19s/it]"
      }
@@ -1512,7 +1506,7 @@
       "description": "",
       "description_tooltip": null,
       "layout": "IPY_MODEL_7529396c14464b7b9e349c6ba003cddc",
-      "placeholder": "​",
+      "placeholder": "\u200b",
       "style": "IPY_MODEL_71ad3ff88d62426abda44fdb300b0484",
       "value": " 1/1 [00:20&lt;00:00,  5.12s/it]"
      }

--- a/real-time-ai-systems/aml/2_aml_training_pipeline.ipynb
+++ b/real-time-ai-systems/aml/2_aml_training_pipeline.ipynb
@@ -8,7 +8,7 @@
     "\n",
     "<span style=\"font-width:bold; font-size: 1.4rem;\"> This notebook explains how to read from a feature group and create training dataset within the feature store. You will train a model on the created training dataset. You will train your model using TensorFlow, although it could just as well be trained with other machine learning frameworks such as Scikit-learn, Keras, and PyTorch. You will also see some of the exploration that can be done in Hopsworks, notably the search functions and the lineage.</span>\n",
     "\n",
-    "## **🗒️ This notebook is divided into the following steps:** \n",
+    "## **\ud83d\uddd2\ufe0f This notebook is divided into the following steps:** \n",
     "\n",
     "1. **Feature Selection**: Select the features you want to train your model on.\n",
     "2. **Feature Transformation**: How the features should be preprocessed.\n",
@@ -24,7 +24,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## <span style='color:#ff5f27'> 📝 Imports"
+    "## <span style='color:#ff5f27'> \ud83d\udcdd Imports"
    ]
   },
   {
@@ -46,7 +46,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## <span style=\"color:#ff5f27;\"> 📡 Connecting to Hopsworks Feature Store </span>"
+    "## <span style=\"color:#ff5f27;\"> \ud83d\udce1 Connecting to Hopsworks Feature Store </span>"
    ]
   },
   {
@@ -67,7 +67,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## <span style=\"color:#ff5f27;\"> 🔪 Feature Selection </span>\n",
+    "## <span style=\"color:#ff5f27;\"> \ud83d\udd2a Feature Selection </span>\n",
     "\n",
     "You start by selecting all the features you want to include for model training/inference."
    ]
@@ -123,7 +123,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### <span style=\"color:#ff5f27;\"> 🤖 Transformation Functions </span>\n",
+    "### <span style=\"color:#ff5f27;\"> \ud83e\udd16 Transformation Functions </span>\n",
     "\n",
     "Transformation functions are a mathematical mapping of input data that may be stateful - requiring statistics from the partent feature view (such as number of instances of a category, or mean value of a numerical feature)\n",
     "\n",
@@ -156,7 +156,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## <span style=\"color:#ff5f27;\"> ⚙️ Feature View Creation </span>\n",
+    "## <span style=\"color:#ff5f27;\"> \u2699\ufe0f Feature View Creation </span>\n",
     "\n",
     "In Hopsworks, you write features to feature groups (where the features are stored) and you read features from feature views. A feature view is a logical view over features, stored in feature groups, and a feature view typically contains the features used by a specific model. This way, feature views enable features, stored in different feature groups, to be reused across many different models. The Feature Views allows schema in form of a query with filters, define a model target feature/label and additional transformation functions.\n",
     "In order to create a Feature View we may use `fs.create_feature_view()`"
@@ -181,7 +181,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## <span style=\"color:#ff5f27;\"> 🏋️ Training Dataset Creation</span>\n",
+    "## <span style=\"color:#ff5f27;\"> \ud83c\udfcb\ufe0f Training Dataset Creation</span>\n",
     "\n",
     "In Hopsworks training data is a query where the projection (set of features) is determined by the parent FeatureView with an optional snapshot on disk of the data returned by the query.\n",
     "\n",
@@ -231,12 +231,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## <span style=\"color:#ff5f27;\"> 👓 Exploration </span>\n",
+    "## <span style=\"color:#ff5f27;\"> \ud83d\udc53 Exploration </span>\n",
     "\n",
     "### Similar to Feature Groups Feature Views and Training Tatasets are now accessible and searchable in the UI\n",
     "![fv-overview](images/feature_views_explore.gif)\n",
     "\n",
-    "## 📊 Statistics\n",
+    "## \ud83d\udcca Statistics\n",
     "We can explore feature statistics in the feature views. "
    ]
   },
@@ -251,7 +251,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# <span style=\"color:#ff5f27;\">🤖 Model Building</span>\n"
+    "# <span style=\"color:#ff5f27;\">\ud83e\udd16 Model Building</span>\n"
    ]
   },
   {
@@ -357,7 +357,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## <span style=\"color:#ff5f27;\"> 🏃 Train Model</span>\n",
+    "## <span style=\"color:#ff5f27;\"> \ud83c\udfc3 Train Model</span>\n",
     "\n",
     "Next we'll train a model. Here, we set the class weight of the positive class to be twice as big as the negative class."
    ]
@@ -366,7 +366,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## <span style=\"color:#ff5f27;\">🧬 Model architecture</span>\n",
+    "## <span style=\"color:#ff5f27;\">\ud83e\uddec Model architecture</span>\n",
     "\n",
     "Key components:\n",
     "\n",
@@ -436,7 +436,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## <span style=\"color:#ff5f27;\">📝 Register model</span>\n",
+    "## <span style=\"color:#ff5f27;\">\ud83d\udcdd Register model</span>\n",
     "\n",
     "One of the features in Hopsworks is the model registry. This is where we can store different versions of models and compare their performance. Models from the registry can then be served as API endpoints."
    ]
@@ -449,7 +449,7 @@
    "source": [
     "# Set the path for exporting the trained model\n",
     "export_path = \"aml_model\"\n",
-    "print('💾 Exporting trained model to: {}'.format(export_path))\n",
+    "print('\ud83d\udcbe Exporting trained model to: {}'.format(export_path))\n",
     "\n",
     "# Get the concrete function for serving the model\n",
     "call = model.serve_function.get_concrete_function(tf.TensorSpec([None, None, None], tf.float32))\n",
@@ -488,7 +488,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## <span style=\"color:#ff5f27;\"> 🚀 Model Deployment</span>\n"
+    "## <span style=\"color:#ff5f27;\"> \ud83d\ude80 Model Deployment</span>\n"
    ]
   },
   {
@@ -563,26 +563,10 @@
    "source": [
     "from hsml.transformer import Transformer\n",
     "\n",
-    "# Get the dataset API from the project\n",
-    "dataset_api = project.get_dataset_api()\n",
-    "\n",
-    "# Upload the transformer script file to the \"Models\" dataset\n",
-    "uploaded_file_path = dataset_api.upload(\n",
-    "    \"aml_model_transformer.py\",   # Name of the script file\n",
-    "    \"Models\",                     # Destination folder in the dataset\n",
-    "    overwrite=True,               # Overwrite the file if it already exists\n",
-    ")\n",
-    "\n",
-    "# Construct the full path to the uploaded transformer script file\n",
-    "transformer_script_path = os.path.join(\n",
-    "    \"/Projects\", \n",
-    "    project.name, \n",
-    "    uploaded_file_path,\n",
-    ")\n",
-    "\n",
-    "# Create a Transformer object using the uploaded script\n",
+    "# `aml_model_transformer.py` is uploaded to HopsFS automatically by the\n",
+    "# SDK when the deployment is saved; no manual dataset_api.upload step needed.\n",
     "transformer_script = Transformer(\n",
-    "    script_file=transformer_script_path,\n",
+    "    script_file=\"aml_model_transformer.py\",\n",
     ")"
    ]
   },
@@ -662,7 +646,7 @@
    "metadata": {},
    "source": [
     "---\n",
-    "## <span style=\"color:#ff5f27;\"> ⏭️ Next: Part 03: Online Inference </span>\n",
+    "## <span style=\"color:#ff5f27;\"> \u23ed\ufe0f Next: Part 03: Online Inference </span>\n",
     "    \n",
     "In the next notebook you will use your deployment for online inference."
    ]

--- a/real-time-ai-systems/fraud_online/2_fraud_online_training_pipeline.ipynb
+++ b/real-time-ai-systems/fraud_online/2_fraud_online_training_pipeline.ipynb
@@ -11,7 +11,7 @@
     "\n",
     "<span style=\"font-width:bold; font-size: 1.4rem;\">This notebook explains how to read from a feature group, create training dataset within the feature store, train a model and save it to model registry.</span>\n",
     "\n",
-    "## 🗒️ This notebook is divided into the following sections:\n",
+    "## \ud83d\uddd2\ufe0f This notebook is divided into the following sections:\n",
     "\n",
     "1. Fetch Feature Groups.\n",
     "2. Define Transformation functions.\n",
@@ -28,7 +28,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## <span style='color:#ff5f27'> 📝 Imports"
+    "## <span style='color:#ff5f27'> \ud83d\udcdd Imports"
    ]
   },
   {
@@ -68,7 +68,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## <span style=\"color:#ff5f27;\"> 📡 Connecting to Hopsworks Feature Store </span>"
+    "## <span style=\"color:#ff5f27;\"> \ud83d\udce1 Connecting to Hopsworks Feature Store </span>"
    ]
   },
   {
@@ -95,7 +95,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## <span style=\"color:#ff5f27;\"> 🔪 Feature Selection </span>\n",
+    "## <span style=\"color:#ff5f27;\"> \ud83d\udd2a Feature Selection </span>\n",
     "\n",
     "You will start by selecting all the features you want to include for model training/inference."
    ]
@@ -148,7 +148,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### <span style=\"color:#ff5f27;\"> 🤖 Transformation Functions </span>\n",
+    "### <span style=\"color:#ff5f27;\"> \ud83e\udd16 Transformation Functions </span>\n",
     "\n",
     "\n",
     "You will preprocess our data using *min-max scaling* on numerical features and *label encoding* on categorical features. To do this you simply define a mapping between our features and transformation functions. This ensures that transformation functions such as *min-max scaling* are fitted only on the training data (and not the validation/test data), which ensures that there is no data leakage."
@@ -174,7 +174,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## <span style=\"color:#ff5f27;\"> ⚙️ Feature View Creation </span>\n",
+    "## <span style=\"color:#ff5f27;\"> \u2699\ufe0f Feature View Creation </span>\n",
     "\n",
     "The Feature Views allows schema in form of a query with filters, define a model target feature/label and additional transformation functions.\n",
     "In order to create or get a Feature View you may use `fs.get_or_create_feature_view()`"
@@ -201,7 +201,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## <span style=\"color:#ff5f27;\"> 🏋️ Training Dataset </span>"
+    "## <span style=\"color:#ff5f27;\"> \ud83c\udfcb\ufe0f Training Dataset </span>"
    ]
   },
   {
@@ -310,7 +310,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## <span style=\"color:#ff5f27;\"> 🧬 Modeling</span>\n",
+    "## <span style=\"color:#ff5f27;\"> \ud83e\uddec Modeling</span>\n",
     "\n",
     "Next you will train a model. Here, you set larger class weight for the positive class."
    ]
@@ -403,7 +403,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## <span style=\"color:#ff5f27;\">📝 Register model</span>\n",
+    "## <span style=\"color:#ff5f27;\">\ud83d\udcdd Register model</span>\n",
     "\n",
     "One of the features in Hopsworks is the model registry. This is where we can store different versions of models and compare their performance. Models from the registry can then be served as API endpoints."
    ]
@@ -502,7 +502,7 @@
     "tags": []
    },
    "source": [
-    "## <a class=\"anchor\" id=\"1.5_bullet\" style=\"color:#ff5f27\"> 🚀 Model Deployment</a>\n",
+    "## <a class=\"anchor\" id=\"1.5_bullet\" style=\"color:#ff5f27\"> \ud83d\ude80 Model Deployment</a>\n",
     "\n",
     "\n",
     "### About Model Serving\n",
@@ -515,7 +515,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### <span style=\"color:#ff5f27;\">📎 Predictor script for Python models</span>\n",
+    "### <span style=\"color:#ff5f27;\">\ud83d\udcce Predictor script for Python models</span>\n",
     "\n",
     "\n",
     "Scikit-learn and XGBoost models are deployed as Python models, in which case you need to provide a **Predict** class that implements the **predict** method. The **predict()** method invokes the model on the inputs and returns the prediction as a list.\n",
@@ -597,17 +597,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Get the dataset API for the current project\n",
-    "dataset_api = project.get_dataset_api()\n",
-    "\n",
-    "# Specify the local file path of the Python script to be uploaded\n",
-    "local_script_path = \"predict_example.py\"\n",
-    "\n",
-    "# Upload the Python script to the \"Models\", and overwrite if it already exists\n",
-    "uploaded_file_path = dataset_api.upload(local_script_path, \"Models\", overwrite=True)\n",
-    "\n",
-    "# Create the full path to the uploaded script for future reference\n",
-    "predictor_script_path = os.path.join(\"/Projects\", project.name, uploaded_file_path)"
+    "# `predict_example.py` is uploaded to HopsFS automatically by the SDK\n",
+    "# when the deployment is saved; no manual dataset_api.upload step needed."
    ]
   },
   {
@@ -627,7 +618,7 @@
     "# Deploy the fraud model\n",
     "deployment = fraud_model.deploy(\n",
     "    name=\"fraudonlinemodeldeployment\",  # Specify a name for the deployment\n",
-    "    script_file=predictor_script_path,  # Provide the path to the Python script for prediction\n",
+    "    script_file=\"predict_example.py\",  # Local path; SDK auto-uploads on save\n",
     ")"
    ]
   },
@@ -723,7 +714,7 @@
    "metadata": {},
    "source": [
     "---\n",
-    "## <span style=\"color:#ff5f27;\">⏭️ **Next:** Part 03: Inference Pipeline</span>\n",
+    "## <span style=\"color:#ff5f27;\">\u23ed\ufe0f **Next:** Part 03: Inference Pipeline</span>\n",
     "\n",
     "In the following notebook you will use your model for Serving Vector Inference.\n"
    ]

--- a/real-time-ai-systems/tiktok_recsys/python/Jupyter/5_create_deployments.ipynb
+++ b/real-time-ai-systems/tiktok_recsys/python/Jupyter/5_create_deployments.ipynb
@@ -5,7 +5,7 @@
    "id": "7a62c0de",
    "metadata": {},
    "source": [
-    "## <span style=\"color:#ff5f27\">👨🏻‍🏫 Create Deployment </span>\n",
+    "## <span style=\"color:#ff5f27\">\ud83d\udc68\ud83c\udffb\u200d\ud83c\udfeb Create Deployment </span>\n",
     "\n",
     "In this notebook, you'll create a deployment for your recommendation system.\n",
     "\n",
@@ -17,7 +17,7 @@
    "id": "9326c452",
    "metadata": {},
    "source": [
-    "## <span style=\"color:#ff5f27\">📝 Imports </span>"
+    "## <span style=\"color:#ff5f27\">\ud83d\udcdd Imports </span>"
    ]
   },
   {
@@ -35,7 +35,7 @@
    "id": "ef743d42",
    "metadata": {},
    "source": [
-    "## <span style=\"color:#ff5f27\">🔮 Connect to Hopsworks Feature Store </span>"
+    "## <span style=\"color:#ff5f27\">\ud83d\udd2e Connect to Hopsworks Feature Store </span>"
    ]
   },
   {
@@ -60,7 +60,7 @@
    "id": "d064e89f",
    "metadata": {},
    "source": [
-    "## <span style=\"color:#ff5f27\">🚀 Ranking Model Deployment </span>\n"
+    "## <span style=\"color:#ff5f27\">\ud83d\ude80 Ranking Model Deployment </span>\n"
    ]
   },
   {
@@ -238,19 +238,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Copy transformer file into Hopsworks File System \n",
-    "uploaded_file_path = dataset_api.upload(\n",
-    "    \"ranking_transformer.py\",    # File name to be uploaded\n",
-    "    \"Resources\",                 # Destination directory in Hopsworks File System \n",
-    "    overwrite=True,              # Overwrite the file if it already exists\n",
-    ") \n",
-    "\n",
-    "# Construct the path to the uploaded transformer script\n",
-    "transformer_script_path = os.path.join(\n",
-    "    \"/Projects\",                 # Root directory for projects in Hopsworks\n",
-    "    project.name,                # Name of the current project\n",
-    "    uploaded_file_path,          # Path to the uploaded file within the project\n",
-    ")"
+    "# `ranking_transformer.py` is uploaded to HopsFS automatically by the\n",
+    "# SDK when the deployment is saved; no manual dataset_api.upload step needed."
    ]
   },
   {
@@ -301,19 +290,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Upload predictor file to Hopsworks\n",
-    "uploaded_file_path = dataset_api.upload(\n",
-    "    \"ranking_predictor.py\", \n",
-    "    \"Resources\", \n",
-    "    overwrite=True,\n",
-    ")\n",
-    "\n",
-    "# Construct the path to the uploaded script\n",
-    "predictor_script_path = os.path.join(\n",
-    "    \"/Projects\", \n",
-    "    project.name, \n",
-    "    uploaded_file_path,\n",
-    ")"
+    "# `ranking_predictor.py` is uploaded to HopsFS automatically by the\n",
+    "# SDK when the deployment is saved; no manual dataset_api.upload step needed."
    ]
   },
   {
@@ -337,7 +315,7 @@
     "\n",
     "# Define transformer\n",
     "ranking_transformer=Transformer(\n",
-    "    script_file=transformer_script_path, \n",
+    "    script_file=\"ranking_transformer.py\", \n",
     "    resources={\"num_instances\": 1},\n",
     ")\n",
     "\n",
@@ -345,7 +323,7 @@
     "ranking_deployment = ranking_model.deploy(\n",
     "    name=ranking_deployment_name,\n",
     "    description=\"Deployment that search for video candidates and scores them based on user metadata\",\n",
-    "    script_file=predictor_script_path,\n",
+    "    script_file=\"ranking_predictor.py\",\n",
     "    resources={\"num_instances\": 1},\n",
     "    transformer=ranking_transformer,\n",
     ")"
@@ -454,7 +432,7 @@
    "id": "5b8dafe6",
    "metadata": {},
    "source": [
-    "## <span style=\"color:#ff5f27\">🚀 Query Model Deployment </span>\n",
+    "## <span style=\"color:#ff5f27\">\ud83d\ude80 Query Model Deployment </span>\n",
     "\n",
     "Next, you'll deploy your query model."
    ]
@@ -584,19 +562,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Copy transformer file into Hopsworks File System\n",
-    "uploaded_file_path = dataset_api.upload(\n",
-    "    \"querymodel_transformer.py\", \n",
-    "    \"Models\", \n",
-    "    overwrite=True,\n",
-    ")\n",
-    "\n",
-    "# Construct the path to the uploaded script\n",
-    "transformer_script_path = os.path.join(\n",
-    "    \"/Projects\", \n",
-    "    project.name, \n",
-    "    uploaded_file_path,\n",
-    ")"
+    "# `querymodel_transformer.py` is uploaded to HopsFS automatically by the\n",
+    "# SDK when the deployment is saved; no manual dataset_api.upload step needed."
    ]
   },
   {
@@ -612,7 +579,7 @@
     "\n",
     "# Define transformer\n",
     "query_model_transformer=Transformer(\n",
-    "    script_file=transformer_script_path, \n",
+    "    script_file=\"querymodel_transformer.py\", \n",
     "    resources={\"num_instances\": 1},\n",
     ")\n",
     "\n",

--- a/real-time-ai-systems/timeseries/2_training_pipeline.ipynb
+++ b/real-time-ai-systems/timeseries/2_training_pipeline.ipynb
@@ -5,7 +5,7 @@
    "id": "498c0916",
    "metadata": {},
    "source": [
-    "## <span style=\"color:#ff5f27\">📝 Imports </span>"
+    "## <span style=\"color:#ff5f27\">\ud83d\udcdd Imports </span>"
    ]
   },
   {
@@ -43,7 +43,7 @@
    "id": "95952e61",
    "metadata": {},
    "source": [
-    "## <span style=\"color:#ff5f27\">🔮 Connect to Hopsworks Feature Store </span>"
+    "## <span style=\"color:#ff5f27\">\ud83d\udd2e Connect to Hopsworks Feature Store </span>"
    ]
   },
   {
@@ -84,7 +84,7 @@
    "id": "4ec81684",
    "metadata": {},
    "source": [
-    "## <span style=\"color:#ff5f27\">🔪 Feature Selection </span>"
+    "## <span style=\"color:#ff5f27\">\ud83d\udd2a Feature Selection </span>"
    ]
   },
   {
@@ -107,7 +107,7 @@
    "id": "8f229b63",
    "metadata": {},
    "source": [
-    "## <span style=\"color:#ff5f27\">🤖 Transformation Functions </span>"
+    "## <span style=\"color:#ff5f27\">\ud83e\udd16 Transformation Functions </span>"
    ]
   },
   {
@@ -138,7 +138,7 @@
    "id": "4f7a0ddc",
    "metadata": {},
    "source": [
-    "## <span style=\"color:#ff5f27\">⚙️ Feature View Creation </span>"
+    "## <span style=\"color:#ff5f27\">\u2699\ufe0f Feature View Creation </span>"
    ]
   },
   {
@@ -163,7 +163,7 @@
    "id": "9b7b990d",
    "metadata": {},
    "source": [
-    "## <span style=\"color:#ff5f27\">🏋️ Training Dataset Creation </span>"
+    "## <span style=\"color:#ff5f27\">\ud83c\udfcb\ufe0f Training Dataset Creation </span>"
    ]
   },
   {
@@ -232,7 +232,7 @@
    "id": "c5816d56",
    "metadata": {},
    "source": [
-    "## <span style=\"color:#ff5f27\">🧬 Modeling </span>\n",
+    "## <span style=\"color:#ff5f27\">\ud83e\uddec Modeling </span>\n",
     "\n",
     "We will use the XGBoost Regressor. XGBoost regressor is a powerful and highly effective machine learning algorithm for regression problems. XGBoost is known for its ability to handle complex relationships in the data, handle missing values, and provide accurate predictions. It's a popular choice in the data science community due to its robustness and excellent predictive performance, making it well-suited for our specific problem."
    ]
@@ -255,7 +255,7 @@
     "\n",
     "# Calculate RMSE on the validation set\n",
     "mse = mean_squared_error(y_test, y_test_pred, squared=False)\n",
-    "print(f\"🎯 Mean Squared Error (MSE): {mse}\")"
+    "print(f\"\ud83c\udfaf Mean Squared Error (MSE): {mse}\")"
    ]
   },
   {
@@ -293,7 +293,7 @@
    "id": "ed7546cf",
    "metadata": {},
    "source": [
-    "## <span style=\"color:#ff5f27\">📝 Register model </span>"
+    "## <span style=\"color:#ff5f27\">\ud83d\udcdd Register model </span>"
    ]
   },
   {
@@ -361,7 +361,7 @@
    "id": "bdb89574",
    "metadata": {},
    "source": [
-    "## <span style=\"color:#ff5f27\">🚀 Model Deployment</span>\n",
+    "## <span style=\"color:#ff5f27\">\ud83d\ude80 Model Deployment</span>\n",
     "\n",
     "**About Model Serving**\n",
     "\n",
@@ -375,7 +375,7 @@
    "id": "d3fadeb6",
    "metadata": {},
    "source": [
-    "## <span style=\"color:#ff5f27\">📎 Predictor script for Python models</span>\n",
+    "## <span style=\"color:#ff5f27\">\ud83d\udcce Predictor script for Python models</span>\n",
     "\n",
     "Scikit-learn and XGBoost models are deployed as Python models, in which case you need to provide a Predict class that implements the predict method. The `predict()` method invokes the model on the inputs and returns the prediction as a list.\n",
     "\n",
@@ -416,7 +416,7 @@
     "\n",
     "        # Load the trained model\n",
     "        self.model = joblib.load(os.environ[\"MODEL_FILES_PATH\"] + \"/xgboost_price_model.pkl\")\n",
-    "        print(\"✅ Initialization Complete\")\n",
+    "        print(\"\u2705 Initialization Complete\")\n",
     "\n",
     "    \n",
     "    def predict(self, id_value):\n",
@@ -443,14 +443,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Get the dataset API from the project\n",
-    "dataset_api = project.get_dataset_api()\n",
-    "\n",
-    "# Upload the file \"predict_example.py\" to the \"Models\" dataset, overwriting if it already exists\n",
-    "uploaded_file_path = dataset_api.upload(\"predict_example.py\", \"Models\", overwrite=True)\n",
-    "\n",
-    "# Create the full path to the uploaded predictor script\n",
-    "predictor_script_path = os.path.join(\"/Projects\", project.name, uploaded_file_path)"
+    "# `predict_example.py` is uploaded to HopsFS automatically by the SDK\n",
+    "# when the deployment is saved; no manual dataset_api.upload step needed."
    ]
   },
   {
@@ -466,7 +460,7 @@
    "id": "71b4628b",
    "metadata": {},
    "source": [
-    "## <span style=\"color:#ff5f27\">🚀 Create the deployment</span>\n",
+    "## <span style=\"color:#ff5f27\">\ud83d\ude80 Create the deployment</span>\n",
     "\n",
     "Here, you fetch the model you want from the model registry and define a configuration for the deployment. For the configuration, you need to specify the serving type (default or KFserving)."
    ]
@@ -481,7 +475,7 @@
     "# Deploy the 'price_model'\n",
     "deployment = price_model.deploy(\n",
     "    name=\"priceonlinemodeldeployment\",  # Specify the deployment name\n",
-    "    script_file=predictor_script_path,  # Provide the path to the predictor script\n",
+    "    script_file=\"predict_example.py\",  # Local path; SDK auto-uploads on save\n",
     ")"
    ]
   },


### PR DESCRIPTION
The hopsworks Python SDK (>= 4.7) auto-uploads local file paths passed as `script_file` / `config_file` to the project's Deployments dataset when a deployment is saved. Drop the manual `dataset_api.upload(...)` + `/Projects/<project>/<path>` reconstruction across 16 tutorials and pass the on-disk filenames directly to `model.deploy()`, `ms.create_transformer()`, and `Transformer(script_file=...)`.

Tutorials updated:
- quickstart.ipynb
- llm-ai-systems/recommender-system/5_create_deployments.ipynb
- real-time-ai-systems/timeseries/2_training_pipeline.ipynb
- real-time-ai-systems/fraud_online/2_fraud_online_training_pipeline.ipynb
- real-time-ai-systems/aml/2_aml_training_pipeline.ipynb
- real-time-ai-systems/tiktok_recsys/python/Jupyter/5_create_deployments.ipynb
- benchmarks/online-inference-pipeline/2_fraud_online_training_pipeline.ipynb
- integrations/neo4j/2_training_pipeline.ipynb
- integrations/pyspark_streaming/2_training_pipeline.ipynb
- 7 vLLM notebooks under api_examples/vllm/

Net -136 lines (16 notebooks).